### PR TITLE
Log peers into an SQLite database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rusqlite"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc785c98d0c872455381e59be1f33a8f3a6b4e852544212e37601cc2ccb21d39"
+dependencies = [
+ "crossbeam-channel",
+ "rusqlite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +877,7 @@ dependencies = [
  "serde",
  "serde_test",
  "tokio",
+ "tokio-rusqlite",
  "toml",
  "tun 0.6.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ strip = true
 tun = { version = "0.6.1", features = ["async"] }
 nullnet-firewall = { git = "https://github.com/GyulyVGC/nullnet-firewall.git" }
 clap = { version = "4.4.18", features = ["derive"] }
-tokio = { version = "1.35.1", features = ["net", "sync", "rt-multi-thread", "macros", "io-util", "time", "fs"] }
+tokio = { version = "1.35.1", features = ["net", "sync", "rt-multi-thread", "macros", "io-util", "time"] }
 notify = "6.1.1"
 network-interface = "1.1.1"
 chrono = { version = "0.4.33", default-features = false }
 serde = { version = "1.0.196", default_features = false, features = ["derive", "alloc"] }
 toml = "0.8.10"
+tokio-rusqlite = "0.5.0"
 
 [dev-dependencies]
 serde_test = "1.0.176"

--- a/src/forward/send.rs
+++ b/src/forward/send.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use nullnet_firewall::{Firewall, FirewallAction, FirewallDirection};
@@ -9,13 +9,13 @@ use tokio::sync::{Mutex, RwLock};
 use tun::AsyncDevice;
 
 use crate::frames::os_frame::OsFrame;
-use crate::peers::peer::Peer;
+use crate::peers::peer::{PeerKey, PeerVal};
 
 pub async fn send(
     device: &Arc<Mutex<ReadHalf<AsyncDevice>>>,
     socket: &Arc<UdpSocket>,
     firewall: &Arc<RwLock<Firewall>>,
-    peers: Arc<RwLock<HashMap<IpAddr, Peer>>>,
+    peers: Arc<RwLock<HashMap<PeerKey, PeerVal>>>,
 ) {
     let mut os_frame = OsFrame::new();
     loop {
@@ -49,7 +49,7 @@ pub async fn send(
 
 async fn get_dst_socket(
     socket_buf: &[u8],
-    peers: &Arc<RwLock<HashMap<IpAddr, Peer>>>,
+    peers: &Arc<RwLock<HashMap<PeerKey, PeerVal>>>,
 ) -> Option<SocketAddr> {
     if socket_buf.len() < 20 {
         None
@@ -58,7 +58,7 @@ async fn get_dst_socket(
         peers
             .read()
             .await
-            .get(&IpAddr::from(dest_ip_slice))
-            .map(Peer::forward_socket_addr)
+            .get(&PeerKey::from_slice(dest_ip_slice))
+            .map(PeerVal::forward_socket_addr)
     }
 }

--- a/src/peers/database.rs
+++ b/src/peers/database.rs
@@ -1,0 +1,67 @@
+use crate::peers::peer::{PeerKey, PeerVal};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, MutexGuard, RwLock};
+use tokio_rusqlite::Connection;
+
+pub async fn update_db(
+    db: &Arc<Mutex<Connection>>,
+    peers: &Arc<RwLock<HashMap<PeerKey, PeerVal>>>,
+) {
+    let connection = db.lock().await;
+    drop_table(&connection).await;
+    create_table(&connection).await;
+    update_table(&connection, peers).await;
+}
+
+async fn create_table<'a>(connection: &MutexGuard<'a, Connection>) {
+    connection
+        .call(|c| {
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS peer (
+                        tun_ip             TEXT PRIMARY KEY,
+                        eth_ip             TEXT NOT NULL,
+                        avg_delay          REAL NOT NULL,
+                        num_seen_unicast   INTEGER NOT NULL,
+                        num_seen_multicast INTEGER NOT NULL,
+                        last_seen          TEXT NOT NULL
+                    )",
+                (),
+            )
+            .unwrap();
+            Ok(())
+        })
+        .await
+        .unwrap();
+}
+
+async fn update_table<'a>(
+    connection: &MutexGuard<'a, Connection>,
+    peers: &Arc<RwLock<HashMap<PeerKey, PeerVal>>>,
+) {
+    for (peer_key, peer_val) in peers.read().await.iter() {
+        let (peer_key, peer_val) = (peer_key.to_owned(), peer_val.to_owned());
+        connection
+            .call(move |c| {
+                c.execute(
+                    "INSERT INTO peer (tun_ip, eth_ip, num_seen_unicast, num_seen_multicast, avg_delay, last_seen)
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    (peer_key.tun_ip.to_string(), peer_val.eth_ip.to_string(), peer_val.num_seen_unicast,
+                     peer_val.num_seen_multicast, peer_val.avg_delay_as_seconds(), peer_val.last_seen.to_string()),
+                ).unwrap();
+                Ok(())
+            })
+            .await
+            .unwrap();
+    }
+}
+
+async fn drop_table<'a>(connection: &MutexGuard<'a, Connection>) {
+    connection
+        .call(|c| {
+            c.execute("DROP TABLE IF EXISTS peer", ()).unwrap();
+            Ok(())
+        })
+        .await
+        .unwrap();
+}

--- a/src/peers/database.rs
+++ b/src/peers/database.rs
@@ -16,12 +16,14 @@ pub async fn manage_db(mut rx: UnboundedReceiver<(Peer, PeerDbAction)>) {
     // make sure peer table exists and it's empty
     setup_db(&connection).await;
 
-    // listen for messages on the channel
-    if let Some((peer, action)) = rx.recv().await {
-        match action {
-            PeerDbAction::Insert => insert_peer(&connection, peer).await,
-            PeerDbAction::Modify => modify_peer(&connection, peer).await,
-            PeerDbAction::Remove => remove_peer(&connection, peer).await,
+    // keep listening for messages on the channel
+    loop {
+        if let Some((peer, action)) = rx.recv().await {
+            match action {
+                PeerDbAction::Insert => insert_peer(&connection, peer).await,
+                PeerDbAction::Modify => modify_peer(&connection, peer).await,
+                PeerDbAction::Remove => remove_peer(&connection, peer).await,
+            }
         }
     }
 }

--- a/src/peers/discovery.rs
+++ b/src/peers/discovery.rs
@@ -232,7 +232,7 @@ async fn update_table<'a>(
                     "INSERT INTO peer (tun_ip, eth_ip, num_seen_unicast, num_seen_multicast, avg_delay, last_seen)
                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                     (peer_key.tun_ip.to_string(), peer_val.eth_ip.to_string(), peer_val.num_seen_unicast,
-                     peer_val.num_seen_multicast, peer_val.avg_delay as f64 / 1_000_000_f64, peer_val.last_seen.to_string()),
+                     peer_val.num_seen_multicast, peer_val.avg_delay_as_seconds(), peer_val.last_seen.to_string()),
                 ).unwrap();
             Ok(())
         })

--- a/src/peers/discovery.rs
+++ b/src/peers/discovery.rs
@@ -1,8 +1,8 @@
 use crate::local_endpoints::LocalEndpoints;
-use crate::peers::database::update_db;
+use crate::peers::database::{manage_db, PeerDbAction};
 use crate::peers::hello::Hello;
 use crate::peers::local_ips::LocalIps;
-use crate::peers::peer::{PeerKey, PeerVal};
+use crate::peers::peer::{Peer, PeerKey, PeerVal};
 use chrono::Utc;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -10,8 +10,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
-use tokio::sync::{Mutex, RwLock};
-use tokio_rusqlite::Connection;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{mpsc, RwLock};
 
 const RETRIES: u64 = 4;
 
@@ -19,8 +19,6 @@ const RETRIES: u64 = 4;
 const TTL: u64 = 60; // * 60;
 const RETRANSMISSION_PERIOD: u64 = TTL / 4;
 const RETRIES_DELTA: u64 = 1;
-
-const SQLITE_PATH: &str = "./peers.sqlite";
 
 pub async fn discover_peers(
     endpoints: LocalEndpoints,
@@ -39,9 +37,14 @@ pub async fn discover_peers(
     let peers_2 = peers.clone();
     let peers_3 = peers.clone();
 
-    let db = Arc::new(Mutex::new(Connection::open(SQLITE_PATH).await.unwrap()));
-    let db_2 = db.clone();
-    let db_3 = db.clone();
+    let (tx, rx) = mpsc::unbounded_channel();
+    let tx_2 = tx.clone();
+    let tx_3 = tx.clone();
+
+    // update peers database
+    tokio::spawn(async move {
+        manage_db(rx).await;
+    });
 
     // listen for multicast hello messages
     tokio::spawn(async move {
@@ -50,19 +53,19 @@ pub async fn discover_peers(
             multicast_socket,
             local_ips,
             peers,
-            db,
+            tx,
         )
         .await;
     });
 
     // listen for unicast hello responses
     tokio::spawn(async move {
-        listen(ListenType::Unicast, socket, local_ips_2, peers_2, db_2).await;
+        listen(ListenType::Unicast, socket, local_ips_2, peers_2, tx_2).await;
     });
 
     // remove inactive peers
     tokio::spawn(async move {
-        remove_inactive_peers(peers_3, db_3).await;
+        remove_inactive_peers(peers_3, tx_3).await;
     });
 
     // periodically send out multicast hello messages
@@ -75,7 +78,7 @@ async fn listen(
     listen_socket: Arc<UdpSocket>,
     local_ips: LocalIps,
     peers: Arc<RwLock<HashMap<PeerKey, PeerVal>>>,
-    db: Arc<Mutex<Connection>>,
+    tx: UnboundedSender<(Peer, PeerDbAction)>,
 ) {
     // used to determine whether a unicast response is required
     let mut should_respond_to;
@@ -97,21 +100,43 @@ async fn listen(
 
         let delay = (now - hello.timestamp).num_microseconds().unwrap();
 
+        let peer_key = PeerKey::from_ip_addr(hello.ips.tun);
         peers
             .write()
             .await
-            .entry(PeerKey::from_ip_addr(hello.ips.tun))
-            .and_modify(|peer| {
-                let since_last_seen = (now - peer.last_seen).num_seconds().unsigned_abs();
+            .entry(peer_key)
+            .and_modify(|peer_val| {
+                let since_last_seen = (now - peer_val.last_seen).num_seconds().unsigned_abs();
                 if hello.is_setup && since_last_seen > RETRIES * RETRIES_DELTA {
-                    should_respond_to = Some(peer.discovery_socket_addr());
+                    should_respond_to = Some(peer_val.discovery_socket_addr());
                 }
-                peer.refresh(delay, &hello, listen_type.is_unicast());
+                peer_val.refresh(delay, &hello, listen_type.is_unicast());
+
+                // update peer db
+                tx.send((
+                    Peer {
+                        key: peer_key,
+                        val: peer_val.to_owned(),
+                    },
+                    PeerDbAction::Modify,
+                ))
+                .unwrap();
             })
             .or_insert_with(|| {
-                let peer = PeerVal::with_details(delay, &hello, listen_type.is_unicast());
-                should_respond_to = Some(peer.discovery_socket_addr());
-                peer
+                let peer_val = PeerVal::with_details(delay, &hello, listen_type.is_unicast());
+                should_respond_to = Some(peer_val.discovery_socket_addr());
+
+                // update peer db
+                tx.send((
+                    Peer {
+                        key: peer_key,
+                        val: peer_val.to_owned(),
+                    },
+                    PeerDbAction::Insert,
+                ))
+                .unwrap();
+
+                peer_val
             });
 
         if let Some(dest_socket_addr) = should_respond_to {
@@ -122,24 +147,22 @@ async fn listen(
                 });
             }
         }
-
-        update_db(&db, &peers).await;
     }
 }
 
 /// Checks for peers inactive for longer than `TTL` seconds and removes them from the peers list.
 async fn remove_inactive_peers(
     peers: Arc<RwLock<HashMap<PeerKey, PeerVal>>>,
-    db: Arc<Mutex<Connection>>,
+    tx: UnboundedSender<(Peer, PeerDbAction)>,
 ) {
     loop {
-        let oldest_peer = peers
+        let oldest_peer_val = peers
             .read()
             .await
             .values()
             .min_by(|p1, p2| p1.last_seen.cmp(&p2.last_seen))
             .cloned();
-        let sleep_time = if let Some(p) = oldest_peer {
+        let sleep_time = if let Some(p) = oldest_peer_val {
             // TODO: timestamps must be monotonic!
             let since_oldest = (Utc::now() - p.last_seen).num_seconds().unsigned_abs();
             TTL.checked_sub(since_oldest).unwrap_or_default()
@@ -149,12 +172,26 @@ async fn remove_inactive_peers(
 
         tokio::time::sleep(Duration::from_secs(sleep_time)).await;
 
-        peers
-            .write()
-            .await
-            .retain(|_, p| (Utc::now() - p.last_seen).num_seconds().unsigned_abs() < TTL);
+        peers.write().await.retain(|peer_key, peer_val| {
+            let retain = (Utc::now() - peer_val.last_seen)
+                .num_seconds()
+                .unsigned_abs()
+                < TTL;
 
-        update_db(&db, &peers).await;
+            // update peer db
+            if !retain {
+                tx.send((
+                    Peer {
+                        key: *peer_key,
+                        val: peer_val.to_owned(),
+                    },
+                    PeerDbAction::Remove,
+                ))
+                .unwrap();
+            }
+
+            retain
+        });
     }
 }
 

--- a/src/peers/discovery.rs
+++ b/src/peers/discovery.rs
@@ -130,7 +130,7 @@ async fn listen(
                 tx.send((
                     Peer {
                         key: peer_key,
-                        val: peer_val.to_owned(),
+                        val: peer_val.clone(),
                     },
                     PeerDbAction::Insert,
                 ))

--- a/src/peers/discovery.rs
+++ b/src/peers/discovery.rs
@@ -1,4 +1,5 @@
 use crate::local_endpoints::LocalEndpoints;
+use crate::peers::database::update_db;
 use crate::peers::hello::Hello;
 use crate::peers::local_ips::LocalIps;
 use crate::peers::peer::{PeerKey, PeerVal};
@@ -9,7 +10,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
-use tokio::sync::{Mutex, MutexGuard, RwLock};
+use tokio::sync::{Mutex, RwLock};
 use tokio_rusqlite::Connection;
 
 const RETRIES: u64 = 4;
@@ -187,65 +188,6 @@ async fn greet(socket: &Arc<UdpSocket>, dest: SocketAddr, local_ips: &LocalIps, 
             .unwrap_or(0);
         tokio::time::sleep(Duration::from_secs(RETRIES_DELTA)).await;
     }
-}
-
-async fn drop_table<'a>(connection: &MutexGuard<'a, Connection>) {
-    connection
-        .call(|c| {
-            c.execute("DROP TABLE IF EXISTS peer", ()).unwrap();
-            Ok(())
-        })
-        .await
-        .unwrap();
-}
-
-async fn create_table<'a>(connection: &MutexGuard<'a, Connection>) {
-    connection
-        .call(|c| {
-            c.execute(
-                "CREATE TABLE IF NOT EXISTS peer (
-                        tun_ip             TEXT PRIMARY KEY,
-                        eth_ip             TEXT NOT NULL,
-                        num_seen_unicast   INTEGER NOT NULL,
-                        num_seen_multicast INTEGER NOT NULL,
-                        avg_delay          REAL NOT NULL,
-                        last_seen          TEXT NOT NULL
-                    )",
-                (),
-            )
-            .unwrap();
-            Ok(())
-        })
-        .await
-        .unwrap();
-}
-
-async fn update_table<'a>(
-    connection: &MutexGuard<'a, Connection>,
-    peers: &Arc<RwLock<HashMap<PeerKey, PeerVal>>>,
-) {
-    for (peer_key, peer_val) in peers.read().await.iter() {
-        let (peer_key, peer_val) = (peer_key.to_owned(), peer_val.to_owned());
-        connection
-        .call(move |c| {
-                c.execute(
-                    "INSERT INTO peer (tun_ip, eth_ip, num_seen_unicast, num_seen_multicast, avg_delay, last_seen)
-                    VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                    (peer_key.tun_ip.to_string(), peer_val.eth_ip.to_string(), peer_val.num_seen_unicast,
-                     peer_val.num_seen_multicast, peer_val.avg_delay_as_seconds(), peer_val.last_seen.to_string()),
-                ).unwrap();
-            Ok(())
-        })
-        .await
-        .unwrap();
-    }
-}
-
-async fn update_db(db: &Arc<Mutex<Connection>>, peers: &Arc<RwLock<HashMap<PeerKey, PeerVal>>>) {
-    let connection = db.lock().await;
-    drop_table(&connection).await;
-    create_table(&connection).await;
-    update_table(&connection, peers).await;
 }
 
 #[derive(Clone)]

--- a/src/peers/mod.rs
+++ b/src/peers/mod.rs
@@ -1,3 +1,4 @@
+pub mod database;
 pub mod discovery;
 mod hello;
 pub mod local_ips;

--- a/src/peers/peer.rs
+++ b/src/peers/peer.rs
@@ -5,8 +5,14 @@ use crate::peers::hello::Hello;
 use chrono::{DateTime, Utc};
 use std::net::{IpAddr, SocketAddr};
 
+/// Struct representing a peer.
+pub struct Peer {
+    pub(crate) key: PeerKey,
+    pub(crate) val: PeerVal,
+}
+
 /// Struct identifying a peer.
-#[derive(Eq, Hash, PartialEq, Clone)]
+#[derive(Eq, Hash, PartialEq, Clone, Copy)]
 pub struct PeerKey {
     /// TUN IP address of the peer.
     pub(crate) tun_ip: IpAddr,

--- a/src/peers/peer.rs
+++ b/src/peers/peer.rs
@@ -1,12 +1,32 @@
+#![allow(clippy::module_name_repetitions)]
+
 use crate::local_endpoints::{DISCOVERY_PORT, FORWARD_PORT};
 use crate::peers::hello::Hello;
 use chrono::{DateTime, Utc};
-use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, SocketAddr};
 
-/// Struct representing a peer.
+/// Struct identifying a peer.
+#[derive(Eq, Hash, PartialEq, Clone)]
+pub struct PeerKey {
+    /// TUN IP address of the peer.
+    pub(crate) tun_ip: IpAddr,
+}
+
+impl PeerKey {
+    pub fn from_slice(slice: [u8; 4]) -> Self {
+        Self {
+            tun_ip: IpAddr::from(slice),
+        }
+    }
+
+    pub fn from_ip_addr(ip_addr: IpAddr) -> Self {
+        Self { tun_ip: ip_addr }
+    }
+}
+
+/// Struct including attributes of a peer.
 #[derive(Clone)]
-pub struct Peer {
+pub struct PeerVal {
     /// Ethernet IP address of this peer.
     pub(crate) eth_ip: IpAddr,
     /// Number unicast hello messages received from this peer.
@@ -19,7 +39,7 @@ pub struct Peer {
     pub(crate) last_seen: DateTime<Utc>,
 }
 
-impl Peer {
+impl PeerVal {
     /// Creates a new peer after receiving a hello message.
     pub fn with_details(delay: i64, hello: &Hello, is_unicast: bool) -> Self {
         Self {
@@ -50,25 +70,5 @@ impl Peer {
     /// Socket address for discovery.
     pub fn discovery_socket_addr(&self) -> SocketAddr {
         SocketAddr::new(self.eth_ip, DISCOVERY_PORT)
-    }
-}
-
-impl Display for Peer {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        #[allow(clippy::cast_precision_loss)]
-        let avg_delay_as_seconds = self.avg_delay as f64 / 1_000_000_f64;
-        writeln!(
-            f,
-            "{}\n\
-            \t - num_seen_unicast:   {}\n\
-            \t - num_seen_multicast: {}\n\
-            \t - last_seen:          {}\n\
-            \t - avg_delay:          {:.4} s",
-            self.eth_ip,
-            self.num_seen_unicast,
-            self.num_seen_multicast,
-            self.last_seen,
-            avg_delay_as_seconds
-        )
     }
 }

--- a/src/peers/peer.rs
+++ b/src/peers/peer.rs
@@ -71,4 +71,10 @@ impl PeerVal {
     pub fn discovery_socket_addr(&self) -> SocketAddr {
         SocketAddr::new(self.eth_ip, DISCOVERY_PORT)
     }
+
+    /// Returns the average delay of messages from this peer, expressed as seconds.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn avg_delay_as_seconds(&self) -> f64 {
+        self.avg_delay as f64 / 1_000_000_f64
+    }
 }


### PR DESCRIPTION
Use an SQLite database instead of a textual file to log the peers list (for monitorability purposes).