### PR TITLE
Add sessions endpoint and force teardown

### DIFF
--- a/members/nullnet-server/src/http_server/mod.rs
+++ b/members/nullnet-server/src/http_server/mod.rs
@@ -1,7 +1,7 @@
 use crate::orchestrator::Orchestrator;
 use crate::services::service_info::ServiceInfo;
 use axum::Router;
-use axum::routing::get;
+use axum::routing::{delete, get};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -13,6 +13,7 @@ mod health;
 mod nodes;
 mod pool;
 mod services;
+mod sessions;
 mod static_files;
 
 const HTTP_PORT: u16 = 8080;
@@ -31,6 +32,8 @@ pub async fn serve(state: AppState) {
         .route("/api/pool", get(pool::pool_handler))
         .route("/api/config", get(config::config_handler))
         .route("/api/graph", get(graph::graph_handler))
+        .route("/api/sessions", get(sessions::list_handler))
+        .route("/api/sessions/:id", delete(sessions::teardown_handler))
         .fallback(get(static_files::static_handler))
         .with_state(state);
 

--- a/members/nullnet-server/src/http_server/sessions.rs
+++ b/members/nullnet-server/src/http_server/sessions.rs
@@ -1,0 +1,93 @@
+use super::AppState;
+use crate::services::changes::{ServiceChange, apply_changes};
+use crate::services::service_info::ServiceInfo;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::Serialize;
+use std::time::UNIX_EPOCH;
+
+#[derive(Serialize)]
+struct SessionJson {
+    id: u32,
+    network_id: u32,
+    client_ip: String,
+    client_net: String,
+    server_net: String,
+    service: String,
+    chain_depth: usize,
+    created_at: u64,
+}
+
+#[derive(Serialize)]
+struct ErrorJson {
+    error: &'static str,
+}
+
+pub(super) async fn list_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let services = state.services.read().await;
+    let mut sessions: Vec<SessionJson> = services
+        .iter()
+        .flat_map(|(name, info)| {
+            if let ServiceInfo::Registered(reg) = info {
+                reg.all_clients_owned()
+                    .into_iter()
+                    .filter_map(|(c, ci, _, _)| {
+                        let proxy_ip = c.is_proxy()?;
+                        Some(SessionJson {
+                            id: ci.net_id(),
+                            network_id: ci.net_id(),
+                            client_ip: proxy_ip.to_string(),
+                            client_net: ci.client_net().to_string(),
+                            server_net: ci.server_net().to_string(),
+                            service: name.clone(),
+                            chain_depth: ci.active_chains(),
+                            created_at: ci
+                                .created_at()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs(),
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                vec![]
+            }
+        })
+        .collect();
+    sessions.sort_by_key(|s| s.id);
+    axum::Json(sessions)
+}
+
+pub(super) async fn teardown_handler(
+    State(state): State<AppState>,
+    Path(id): Path<u32>,
+) -> impl IntoResponse {
+    let mut services = state.services.write().await;
+
+    let found = services.iter().find_map(|(name, info)| {
+        if let ServiceInfo::Registered(reg) = info {
+            reg.all_clients_owned()
+                .into_iter()
+                .find(|(c, ci, _, _)| c.is_proxy().is_some() && ci.net_id() == id)
+                .map(|(client, _, _, _)| (name.clone(), client))
+        } else {
+            None
+        }
+    });
+
+    let Some((name, client)) = found else {
+        return (
+            StatusCode::NOT_FOUND,
+            axum::Json(ErrorJson {
+                error: "session not found",
+            }),
+        )
+            .into_response();
+    };
+
+    let changes = vec![ServiceChange::ForceSessionTeardown { name, client }];
+    apply_changes(changes, &mut services, None, &state.orchestrator).await;
+
+    StatusCode::NO_CONTENT.into_response()
+}

--- a/members/nullnet-server/src/services/changes.rs
+++ b/members/nullnet-server/src/services/changes.rs
@@ -26,6 +26,8 @@ pub(crate) enum ServiceChange {
     ProxyDisconnected { ip: IpAddr },
     /// A proxy client's timeout expired; tear down its chains.
     ProxyClientTimedOut { name: String, client: Client },
+    /// An operator explicitly requested teardown of a proxy session.
+    ForceSessionTeardown { name: String, client: Client },
 }
 
 enum ProxyFilter<'a> {
@@ -671,6 +673,19 @@ pub(crate) async fn apply_changes(
             ServiceChange::ProxyClientTimedOut { name, client } => {
                 println!(
                     "Proxy client '{}' timed out on service '{name}'",
+                    client.display_name()
+                );
+                teardown_chain(
+                    &name,
+                    services,
+                    orchestrator,
+                    ProxyFilter::ByClient(&client),
+                )
+                .await;
+            }
+            ServiceChange::ForceSessionTeardown { name, client } => {
+                println!(
+                    "Force teardown of proxy client '{}' on service '{name}'",
                     client.display_name()
                 );
                 teardown_chain(

--- a/members/nullnet-server/src/services/clients.rs
+++ b/members/nullnet-server/src/services/clients.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 #[derive(Clone, Default, Debug)]
 pub(super) struct Clients {
@@ -92,6 +92,7 @@ pub(crate) struct ClientInfo {
     time_ms: u128,
     active_chains: usize,
     latest: Instant,
+    created_at: SystemTime,
     docker_container: Option<String>,
 }
 
@@ -112,6 +113,7 @@ impl ClientInfo {
             time_ms,
             active_chains: 0,
             latest: Instant::now(),
+            created_at: SystemTime::now(),
             docker_container,
         }
     }
@@ -125,6 +127,7 @@ impl ClientInfo {
             time_ms: 0,
             active_chains: 0,
             latest: Instant::now(),
+            created_at: SystemTime::now(),
             docker_container: None,
         }
     }
@@ -166,11 +169,15 @@ impl ClientInfo {
         self.active_chains = self.active_chains.saturating_sub(num_chains);
     }
 
-    pub(super) fn active_chains(&self) -> usize {
+    pub(crate) fn active_chains(&self) -> usize {
         self.active_chains
     }
 
     pub(super) fn latest(&self) -> Instant {
         self.latest
+    }
+
+    pub(crate) fn created_at(&self) -> SystemTime {
+        self.created_at
     }
 }


### PR DESCRIPTION
# Sessions Endpoint + Force Teardown

## What

- `GET /api/sessions` — lists all active proxy-initiated sessions
- `DELETE /api/sessions/:id` — force tears down a session by network ID

## Response shape

```json
[
  {
    "id": 42,
    "network_id": 42,
    "client_ip": "10.0.1.5",
    "client_net": "169.254.0.1",
    "server_net": "169.254.0.2",
    "service": "api",
    "chain_depth": 2,
    "created_at": 1747607876
  }
]
```

`created_at` is a Unix UTC timestamp. `chain_depth` is the number of active dependency chains sharing this session.

`DELETE` returns `204` on success, `404` if the session does not exist or has already been torn down.

## What counts as a session

Only proxy-initiated connections are surfaced — these are networks set up by the proxy component on behalf of an end user. Service-to-service edges (set up automatically from `proxy_deps` / `triggers` config) are infrastructure links, not operator-visible sessions, and are not included.

## Teardown path

Force teardown uses a dedicated `ServiceChange::ForceSessionTeardown` variant rather than reusing `ProxyClientTimedOut`. The teardown logic is identical, but the intent is distinct — nothing has timed out.

## Changes

- `http_server/sessions.rs` — new file with both handlers
- `http_server/mod.rs` — two new routes wired
- `services/changes.rs` — `ForceSessionTeardown` variant added to `ServiceChange`
- `services/clients.rs` — `created_at: SystemTime` field added to `ClientInfo`; `active_chains()` visibility widened to `pub(crate)`
