### PR TITLE
Event system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,6 +2039,7 @@ dependencies = [
  "axum",
  "chrono",
  "ctrlc",
+ "futures",
  "gag",
  "ipnetwork",
  "mime_guess",
@@ -2050,6 +2051,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "toml",
  "tonic",
  "tonic-prost",
@@ -3474,6 +3476,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/members/nullnet-client/src/control_channel.rs
+++ b/members/nullnet-client/src/control_channel.rs
@@ -132,7 +132,7 @@ async fn handle_vlan_setup(
         fire_event(&grpc, AgentEventKind::VlanSetupFailed(AgentVlanSetupFailed {
             vlan_id: message.vlan_id,
             local_veth: local_veth.to_string(),
-            error_reason: e.to_string(),
+            error_reason: e.to_str().to_string(),
         }));
     })?;
 
@@ -190,7 +190,7 @@ async fn handle_vlan_teardown(
     let vlan_id = u16::try_from(message.vlan_id).handle_err(location!()).inspect_err(|e| {
         fire_event(&grpc, AgentEventKind::VlanTeardownFailed(AgentVlanTeardownFailed {
             vlan_id: message.vlan_id,
-            error_reason: e.to_string(),
+            error_reason: e.to_str().to_string(),
         }));
     })?;
 

--- a/members/nullnet-client/src/control_channel.rs
+++ b/members/nullnet-client/src/control_channel.rs
@@ -5,14 +5,14 @@ use crate::peers::peer::{Peers, VethKey};
 use ipnetwork::Ipv4Network;
 use nullnet_grpc_lib::NullnetGrpcInterface;
 use nullnet_grpc_lib::nullnet_grpc::{
-    AgentEvent, HostMapping, MsgId, VlanSetup, VlanTeardown, VxlanSetup, VxlanTeardown,
-    agent_event::Event as AgentEventKind, net_message,
+    AgentControlChannelAckFailed, AgentControlChannelClosed, AgentControlChannelEstablished,
+    AgentDnatInstallFailed, AgentHostMappingFailed, AgentVlanSetupCompleted, AgentVlanSetupFailed,
+    AgentVlanTeardownFailed, AgentVxlanSetupCompleted, AgentVxlanSetupFailed,
+    AgentVxlanTeardownFailed,
 };
 use nullnet_grpc_lib::nullnet_grpc::{
-    AgentControlChannelAckFailed, AgentControlChannelClosed, AgentControlChannelEstablished,
-    AgentDnatInstallFailed, AgentHostMappingFailed, AgentVlanSetupCompleted,
-    AgentVlanSetupFailed, AgentVlanTeardownFailed, AgentVxlanSetupCompleted,
-    AgentVxlanSetupFailed, AgentVxlanTeardownFailed,
+    AgentEvent, HostMapping, MsgId, VlanSetup, VlanTeardown, VxlanSetup, VxlanTeardown,
+    agent_event::Event as AgentEventKind, net_message,
 };
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::net::Ipv4Addr;
@@ -42,7 +42,10 @@ pub(crate) async fn control_channel(
         .await
         .handle_err(location!())?;
 
-    fire_event(&server, AgentEventKind::ControlChannelEstablished(AgentControlChannelEstablished {}));
+    fire_event(
+        &server,
+        AgentEventKind::ControlChannelEstablished(AgentControlChannelEstablished {}),
+    );
 
     while let Ok(Some(message)) = inbound.message().await {
         let rtnetlink_handle = rtnetlink_handle.clone();
@@ -92,14 +95,22 @@ pub(crate) async fn control_channel(
             Some(net_message::Message::VxlanTeardown(vxlan_teardown)) => {
                 let triggers_state = triggers_state.clone();
                 tokio::spawn(async move {
-                    handle_vxlan_teardown(vxlan_teardown, triggers_state, host_mappings_state, server);
+                    handle_vxlan_teardown(
+                        vxlan_teardown,
+                        triggers_state,
+                        host_mappings_state,
+                        server,
+                    );
                 });
             }
             None => {}
         }
     }
 
-    fire_event(&server, AgentEventKind::ControlChannelClosed(AgentControlChannelClosed {}));
+    fire_event(
+        &server,
+        AgentEventKind::ControlChannelClosed(AgentControlChannelClosed {}),
+    );
 
     Ok(())
 }
@@ -128,13 +139,18 @@ async fn handle_vlan_setup(
         .remote_veth
         .parse::<Ipv4Addr>()
         .handle_err(location!())?;
-    let vlan_id = u16::try_from(message.vlan_id).handle_err(location!()).inspect_err(|e| {
-        fire_event(&grpc, AgentEventKind::VlanSetupFailed(AgentVlanSetupFailed {
-            vlan_id: message.vlan_id,
-            local_veth: local_veth.to_string(),
-            error_reason: e.to_str().to_string(),
-        }));
-    })?;
+    let vlan_id = u16::try_from(message.vlan_id)
+        .handle_err(location!())
+        .inspect_err(|e| {
+            fire_event(
+                &grpc,
+                AgentEventKind::VlanSetupFailed(AgentVlanSetupFailed {
+                    vlan_id: message.vlan_id,
+                    local_veth: local_veth.to_string(),
+                    error_reason: e.to_str().to_string(),
+                }),
+            );
+        })?;
 
     // setup VLAN on this machine
     let init_t = std::time::Instant::now();
@@ -158,24 +174,35 @@ async fn handle_vlan_setup(
     // add host mapping if needed
     if let Some(host_mapping) = &message.host_mapping {
         if add_host_mapping(host_mapping, None).is_err() {
-            fire_event(&grpc, AgentEventKind::HostMappingFailed(AgentHostMappingFailed {
-                hostname: host_mapping.name.clone(),
-                ip: host_mapping.ip.clone(),
-                docker_container: None,
-            }));
+            fire_event(
+                &grpc,
+                AgentEventKind::HostMappingFailed(AgentHostMappingFailed {
+                    hostname: host_mapping.name.clone(),
+                    ip: host_mapping.ip.clone(),
+                    docker_container: None,
+                }),
+            );
         }
         host_mappings_state.record_vlan(vlan_id, host_mapping.clone());
     }
 
     // acknowledge message
     if outbound.send(msg_id.clone()).await.is_err() {
-        fire_event(&grpc, AgentEventKind::ControlChannelAckFailed(AgentControlChannelAckFailed {
-            msg_id: msg_id.id.clone(),
-            message_type: "vlan_setup".to_string(),
-        }));
+        fire_event(
+            &grpc,
+            AgentEventKind::ControlChannelAckFailed(AgentControlChannelAckFailed {
+                msg_id: msg_id.id.clone(),
+                message_type: "vlan_setup".to_string(),
+            }),
+        );
     }
 
-    fire_event(&grpc, AgentEventKind::VlanSetupCompleted(AgentVlanSetupCompleted { vlan_id: u32::from(vlan_id) }));
+    fire_event(
+        &grpc,
+        AgentEventKind::VlanSetupCompleted(AgentVlanSetupCompleted {
+            vlan_id: u32::from(vlan_id),
+        }),
+    );
 
     Ok(())
 }
@@ -187,12 +214,17 @@ async fn handle_vlan_teardown(
     host_mappings_state: Arc<HostMappingsState>,
     grpc: NullnetGrpcInterface,
 ) -> Result<(), Error> {
-    let vlan_id = u16::try_from(message.vlan_id).handle_err(location!()).inspect_err(|e| {
-        fire_event(&grpc, AgentEventKind::VlanTeardownFailed(AgentVlanTeardownFailed {
-            vlan_id: message.vlan_id,
-            error_reason: e.to_str().to_string(),
-        }));
-    })?;
+    let vlan_id = u16::try_from(message.vlan_id)
+        .handle_err(location!())
+        .inspect_err(|e| {
+            fire_event(
+                &grpc,
+                AgentEventKind::VlanTeardownFailed(AgentVlanTeardownFailed {
+                    vlan_id: message.vlan_id,
+                    error_reason: e.to_str().to_string(),
+                }),
+            );
+        })?;
 
     // teardown VLAN on this machine
     let init_t = std::time::Instant::now();
@@ -266,11 +298,14 @@ async fn handle_vxlan_setup(
         _ => 0,
     };
     if error_code != 0 {
-        fire_event(&grpc, AgentEventKind::VxlanSetupFailed(AgentVxlanSetupFailed {
-            vxlan_id,
-            ns_name: ns_name.clone(),
-            error_code,
-        }));
+        fire_event(
+            &grpc,
+            AgentEventKind::VxlanSetupFailed(AgentVxlanSetupFailed {
+                vxlan_id,
+                ns_name: ns_name.clone(),
+                error_code,
+            }),
+        );
     }
     let _ = script_result.handle_err(location!());
     println!(
@@ -282,11 +317,14 @@ async fn handle_vxlan_setup(
     // add host mapping if needed
     if let Some(host_mapping) = &message.host_mapping {
         if add_host_mapping(host_mapping, message.docker_container.as_deref()).is_err() {
-            fire_event(&grpc, AgentEventKind::HostMappingFailed(AgentHostMappingFailed {
-                hostname: host_mapping.name.clone(),
-                ip: host_mapping.ip.clone(),
-                docker_container: message.docker_container.clone(),
-            }));
+            fire_event(
+                &grpc,
+                AgentEventKind::HostMappingFailed(AgentHostMappingFailed {
+                    hostname: host_mapping.name.clone(),
+                    ip: host_mapping.ip.clone(),
+                    docker_container: message.docker_container.clone(),
+                }),
+            );
         }
         host_mappings_state.record_vxlan(
             vxlan_id,
@@ -303,26 +341,32 @@ async fn handle_vxlan_setup(
             dnat::install(dnat_port, overlay_ip);
             triggers_state.mark_active(dnat_port, vxlan_id, overlay_ip);
         } else if message.dnat_port.is_some() {
-            fire_event(&grpc, AgentEventKind::DnatInstallFailed(AgentDnatInstallFailed {
-                port: message.dnat_port.unwrap_or(0),
-                overlay_ip: host_mapping.ip.clone(),
-            }));
+            fire_event(
+                &grpc,
+                AgentEventKind::DnatInstallFailed(AgentDnatInstallFailed {
+                    port: message.dnat_port.unwrap_or(0),
+                    overlay_ip: host_mapping.ip.clone(),
+                }),
+            );
         }
     }
 
     // acknowledge message
     if outbound.send(msg_id.clone()).await.is_err() {
-        fire_event(&grpc, AgentEventKind::ControlChannelAckFailed(AgentControlChannelAckFailed {
-            msg_id: msg_id.id.clone(),
-            message_type: "vxlan_setup".to_string(),
-        }));
+        fire_event(
+            &grpc,
+            AgentEventKind::ControlChannelAckFailed(AgentControlChannelAckFailed {
+                msg_id: msg_id.id.clone(),
+                message_type: "vxlan_setup".to_string(),
+            }),
+        );
     }
 
     if error_code == 0 {
-        fire_event(&grpc, AgentEventKind::VxlanSetupCompleted(AgentVxlanSetupCompleted {
-            vxlan_id,
-            ns_name,
-        }));
+        fire_event(
+            &grpc,
+            AgentEventKind::VxlanSetupCompleted(AgentVxlanSetupCompleted { vxlan_id, ns_name }),
+        );
     }
 
     Ok(())
@@ -364,11 +408,14 @@ fn handle_vxlan_teardown(
         _ => 0,
     };
     if error_code != 0 {
-        fire_event(&grpc, AgentEventKind::VxlanTeardownFailed(AgentVxlanTeardownFailed {
-            vxlan_id,
-            ns_name,
-            error_code,
-        }));
+        fire_event(
+            &grpc,
+            AgentEventKind::VxlanTeardownFailed(AgentVxlanTeardownFailed {
+                vxlan_id,
+                ns_name,
+                error_code,
+            }),
+        );
     }
     let _ = script_result.handle_err(location!());
 

--- a/members/nullnet-client/src/control_channel.rs
+++ b/members/nullnet-client/src/control_channel.rs
@@ -397,7 +397,7 @@ fn handle_vxlan_teardown(
     let br_name = message.br_name;
 
     let mut cmd = std::process::Command::new("./vxlan_scripts/vxlan-teardown.sh");
-    cmd.arg(&vxlan_id.to_string()).arg(&ns_name).arg(&br_name);
+    cmd.arg(vxlan_id.to_string()).arg(&ns_name).arg(&br_name);
     if let Some(container) = &message.docker_container {
         cmd.arg(container);
     }

--- a/members/nullnet-client/src/control_channel.rs
+++ b/members/nullnet-client/src/control_channel.rs
@@ -5,13 +5,29 @@ use crate::peers::peer::{Peers, VethKey};
 use ipnetwork::Ipv4Network;
 use nullnet_grpc_lib::NullnetGrpcInterface;
 use nullnet_grpc_lib::nullnet_grpc::{
-    HostMapping, MsgId, VlanSetup, VlanTeardown, VxlanSetup, VxlanTeardown, net_message,
+    AgentEvent, HostMapping, MsgId, VlanSetup, VlanTeardown, VxlanSetup, VxlanTeardown,
+    agent_event::Event as AgentEventKind, net_message,
+};
+use nullnet_grpc_lib::nullnet_grpc::{
+    AgentControlChannelAckFailed, AgentControlChannelClosed, AgentControlChannelEstablished,
+    AgentDnatInstallFailed, AgentHostMappingFailed, AgentVlanSetupCompleted,
+    AgentVlanSetupFailed, AgentVlanTeardownFailed, AgentVxlanSetupCompleted,
+    AgentVxlanSetupFailed, AgentVxlanTeardownFailed,
 };
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{RwLock, mpsc};
+
+/// Fire-and-forget: send an agent event to the server without blocking the caller.
+fn fire_event(grpc: &NullnetGrpcInterface, kind: AgentEventKind) {
+    let grpc = grpc.clone();
+    let event = AgentEvent { event: Some(kind) };
+    tokio::spawn(async move {
+        let _ = grpc.report_event(event).await;
+    });
+}
 
 pub(crate) async fn control_channel(
     server: NullnetGrpcInterface,
@@ -26,11 +42,14 @@ pub(crate) async fn control_channel(
         .await
         .handle_err(location!())?;
 
+    fire_event(&server, AgentEventKind::ControlChannelEstablished(AgentControlChannelEstablished {}));
+
     while let Ok(Some(message)) = inbound.message().await {
         let rtnetlink_handle = rtnetlink_handle.clone();
         let peers = peers.clone();
         let outbound = outbound.clone();
         let host_mappings_state = host_mappings_state.clone();
+        let server = server.clone();
         match message.message {
             Some(net_message::Message::VlanSetup(vlan_setup)) => {
                 tokio::spawn(async move {
@@ -40,6 +59,7 @@ pub(crate) async fn control_channel(
                         peers,
                         outbound,
                         host_mappings_state,
+                        server,
                     )
                     .await;
                 });
@@ -51,6 +71,7 @@ pub(crate) async fn control_channel(
                         rtnetlink_handle,
                         peers,
                         host_mappings_state,
+                        server,
                     )
                     .await;
                 });
@@ -63,6 +84,7 @@ pub(crate) async fn control_channel(
                         outbound,
                         triggers_state,
                         host_mappings_state,
+                        server,
                     )
                     .await;
                 });
@@ -70,12 +92,14 @@ pub(crate) async fn control_channel(
             Some(net_message::Message::VxlanTeardown(vxlan_teardown)) => {
                 let triggers_state = triggers_state.clone();
                 tokio::spawn(async move {
-                    handle_vxlan_teardown(vxlan_teardown, triggers_state, host_mappings_state);
+                    handle_vxlan_teardown(vxlan_teardown, triggers_state, host_mappings_state, server);
                 });
             }
             None => {}
         }
     }
+
+    fire_event(&server, AgentEventKind::ControlChannelClosed(AgentControlChannelClosed {}));
 
     Ok(())
 }
@@ -86,10 +110,11 @@ async fn handle_vlan_setup(
     peers: Arc<RwLock<Peers>>,
     outbound: Sender<MsgId>,
     host_mappings_state: Arc<HostMappingsState>,
+    grpc: NullnetGrpcInterface,
 ) -> Result<(), Error> {
     let msg_id = &message
         .msg_id
-        .ok_or("Missing message ID in VXLAN setup message")
+        .ok_or("Missing message ID in VLAN setup message")
         .handle_err(location!())?;
     let local_veth = message
         .local_veth
@@ -103,7 +128,13 @@ async fn handle_vlan_setup(
         .remote_veth
         .parse::<Ipv4Addr>()
         .handle_err(location!())?;
-    let vlan_id = u16::try_from(message.vlan_id).handle_err(location!())?;
+    let vlan_id = u16::try_from(message.vlan_id).handle_err(location!()).inspect_err(|e| {
+        fire_event(&grpc, AgentEventKind::VlanSetupFailed(AgentVlanSetupFailed {
+            vlan_id: message.vlan_id,
+            local_veth: local_veth.to_string(),
+            error_reason: e.to_string(),
+        }));
+    })?;
 
     // setup VLAN on this machine
     let init_t = std::time::Instant::now();
@@ -126,12 +157,25 @@ async fn handle_vlan_setup(
 
     // add host mapping if needed
     if let Some(host_mapping) = &message.host_mapping {
-        let _ = add_host_mapping(host_mapping, None);
+        if add_host_mapping(host_mapping, None).is_err() {
+            fire_event(&grpc, AgentEventKind::HostMappingFailed(AgentHostMappingFailed {
+                hostname: host_mapping.name.clone(),
+                ip: host_mapping.ip.clone(),
+                docker_container: None,
+            }));
+        }
         host_mappings_state.record_vlan(vlan_id, host_mapping.clone());
     }
 
     // acknowledge message
-    let _ = outbound.send(msg_id.clone()).await;
+    if outbound.send(msg_id.clone()).await.is_err() {
+        fire_event(&grpc, AgentEventKind::ControlChannelAckFailed(AgentControlChannelAckFailed {
+            msg_id: msg_id.id.clone(),
+            message_type: "vlan_setup".to_string(),
+        }));
+    }
+
+    fire_event(&grpc, AgentEventKind::VlanSetupCompleted(AgentVlanSetupCompleted { vlan_id: u32::from(vlan_id) }));
 
     Ok(())
 }
@@ -141,8 +185,14 @@ async fn handle_vlan_teardown(
     rtnetlink_handle: RtNetLinkHandle,
     peers: Arc<RwLock<Peers>>,
     host_mappings_state: Arc<HostMappingsState>,
+    grpc: NullnetGrpcInterface,
 ) -> Result<(), Error> {
-    let vlan_id = u16::try_from(message.vlan_id).handle_err(location!())?;
+    let vlan_id = u16::try_from(message.vlan_id).handle_err(location!()).inspect_err(|e| {
+        fire_event(&grpc, AgentEventKind::VlanTeardownFailed(AgentVlanTeardownFailed {
+            vlan_id: message.vlan_id,
+            error_reason: e.to_string(),
+        }));
+    })?;
 
     // teardown VLAN on this machine
     let init_t = std::time::Instant::now();
@@ -170,6 +220,7 @@ async fn handle_vxlan_setup(
     outbound: Sender<MsgId>,
     triggers_state: Arc<TriggersState>,
     host_mappings_state: Arc<HostMappingsState>,
+    grpc: NullnetGrpcInterface,
 ) -> Result<(), Error> {
     let msg_id = &message
         .msg_id
@@ -208,7 +259,20 @@ async fn handle_vxlan_setup(
     if let Some(container) = &message.docker_container {
         cmd.arg(container);
     }
-    let _ = cmd.spawn().map(|mut c| c.wait()).handle_err(location!());
+    let script_result = cmd.spawn().and_then(|mut c| c.wait());
+    let error_code = match &script_result {
+        Ok(status) if !status.success() => status.code().unwrap_or(-1),
+        Err(_) => -1,
+        _ => 0,
+    };
+    if error_code != 0 {
+        fire_event(&grpc, AgentEventKind::VxlanSetupFailed(AgentVxlanSetupFailed {
+            vxlan_id,
+            ns_name: ns_name.clone(),
+            error_code,
+        }));
+    }
+    let _ = script_result.handle_err(location!());
     println!(
         "VXLAN {vxlan_id} setup completed in {} ms (docker: {})",
         init_t.elapsed().as_millis(),
@@ -217,7 +281,13 @@ async fn handle_vxlan_setup(
 
     // add host mapping if needed
     if let Some(host_mapping) = &message.host_mapping {
-        let _ = add_host_mapping(host_mapping, message.docker_container.as_deref());
+        if add_host_mapping(host_mapping, message.docker_container.as_deref()).is_err() {
+            fire_event(&grpc, AgentEventKind::HostMappingFailed(AgentHostMappingFailed {
+                hostname: host_mapping.name.clone(),
+                ip: host_mapping.ip.clone(),
+                docker_container: message.docker_container.clone(),
+            }));
+        }
         host_mappings_state.record_vxlan(
             vxlan_id,
             host_mapping.clone(),
@@ -232,11 +302,28 @@ async fn handle_vxlan_setup(
         {
             dnat::install(dnat_port, overlay_ip);
             triggers_state.mark_active(dnat_port, vxlan_id, overlay_ip);
+        } else if message.dnat_port.is_some() {
+            fire_event(&grpc, AgentEventKind::DnatInstallFailed(AgentDnatInstallFailed {
+                port: message.dnat_port.unwrap_or(0),
+                overlay_ip: host_mapping.ip.clone(),
+            }));
         }
     }
 
     // acknowledge message
-    let _ = outbound.send(msg_id.clone()).await;
+    if outbound.send(msg_id.clone()).await.is_err() {
+        fire_event(&grpc, AgentEventKind::ControlChannelAckFailed(AgentControlChannelAckFailed {
+            msg_id: msg_id.id.clone(),
+            message_type: "vxlan_setup".to_string(),
+        }));
+    }
+
+    if error_code == 0 {
+        fire_event(&grpc, AgentEventKind::VxlanSetupCompleted(AgentVxlanSetupCompleted {
+            vxlan_id,
+            ns_name,
+        }));
+    }
 
     Ok(())
 }
@@ -245,6 +332,7 @@ fn handle_vxlan_teardown(
     message: VxlanTeardown,
     triggers_state: Arc<TriggersState>,
     host_mappings_state: Arc<HostMappingsState>,
+    grpc: NullnetGrpcInterface,
 ) {
     // remove DNAT before tearing the tunnel down so existing flows reset cleanly
     if let Some((port, overlay_ip)) = triggers_state.remove_by_vxlan(message.vxlan_id) {
@@ -260,16 +348,29 @@ fn handle_vxlan_teardown(
     // teardown VXLAN on this machine
     let init_t = std::time::Instant::now();
 
-    let vxlan_id = message.vxlan_id.to_string();
-    let ns_name = message.ns_name;
+    let vxlan_id = message.vxlan_id;
+    let ns_name = message.ns_name.clone();
     let br_name = message.br_name;
 
     let mut cmd = std::process::Command::new("./vxlan_scripts/vxlan-teardown.sh");
-    cmd.arg(&vxlan_id).arg(&ns_name).arg(&br_name);
+    cmd.arg(&vxlan_id.to_string()).arg(&ns_name).arg(&br_name);
     if let Some(container) = &message.docker_container {
         cmd.arg(container);
     }
-    let _ = cmd.spawn().map(|mut c| c.wait()).handle_err(location!());
+    let script_result = cmd.spawn().and_then(|mut c| c.wait());
+    let error_code = match &script_result {
+        Ok(status) if !status.success() => status.code().unwrap_or(-1),
+        Err(_) => -1,
+        _ => 0,
+    };
+    if error_code != 0 {
+        fire_event(&grpc, AgentEventKind::VxlanTeardownFailed(AgentVxlanTeardownFailed {
+            vxlan_id,
+            ns_name,
+            error_code,
+        }));
+    }
+    let _ = script_result.handle_err(location!());
 
     println!(
         "VXLAN teardown completed in {} ms",

--- a/members/nullnet-client/src/main.rs
+++ b/members/nullnet-client/src/main.rs
@@ -15,7 +15,7 @@ use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watche
 use nullnet_firewall::{DataLink, Firewall, FirewallError, LogLevel};
 use nullnet_grpc_lib::NullnetGrpcInterface;
 use nullnet_grpc_lib::nullnet_grpc::{
-    AgentEvent, Net, Services, ServicesListResponse,
+    AgentEvent, Net, Services,
     agent_event::Event as AgentEventKind,
     AgentBackendTriggerSendFailed, AgentFirewallRulesLoadFailed,
     AgentServicesListUpdateFailed, AgentServicesListUpdated,
@@ -130,8 +130,9 @@ async fn main() -> Result<(), Error> {
     ebpf::load::load_ebpf(&ETH_NAME, config_rx, trigger_tx);
 
     // declare services + push trigger config to the eBPF observer on each refresh
+    let grpc_server_ds = grpc_server.clone();
     tokio::spawn(async move {
-        declare_services(grpc_server, config_tx)
+        declare_services(grpc_server_ds, config_tx)
             .await
             .expect("Failed to declare services");
     });

--- a/members/nullnet-client/src/main.rs
+++ b/members/nullnet-client/src/main.rs
@@ -247,24 +247,24 @@ async fn set_firewall_rules(
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 let result = firewall.write().await.set_rules(&firewall_path_owned);
                 print_info(&result, is_init);
-                if let Err(ref err) = result {
-                    if let Some(ref g) = grpc {
-                        let g = g.clone();
-                        let path = firewall_path_owned.clone();
-                        let error_message = err.to_string();
-                        tokio::spawn(async move {
-                            let _ = g
-                                .report_event(AgentEvent {
-                                    event: Some(AgentEventKind::FirewallRulesLoadFailed(
-                                        AgentFirewallRulesLoadFailed {
-                                            path,
-                                            error_message,
-                                        },
-                                    )),
-                                })
-                                .await;
-                        });
-                    }
+                if let Err(ref err) = result
+                    && let Some(ref g) = grpc
+                {
+                    let g = g.clone();
+                    let path = firewall_path_owned.clone();
+                    let error_message = err.to_string();
+                    tokio::spawn(async move {
+                        let _ = g
+                            .report_event(AgentEvent {
+                                event: Some(AgentEventKind::FirewallRulesLoadFailed(
+                                    AgentFirewallRulesLoadFailed {
+                                        path,
+                                        error_message,
+                                    },
+                                )),
+                            })
+                            .await;
+                    });
                 }
                 if result.is_ok() && is_init {
                     return Ok(());

--- a/members/nullnet-client/src/main.rs
+++ b/members/nullnet-client/src/main.rs
@@ -14,7 +14,12 @@ use clap::Parser;
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use nullnet_firewall::{DataLink, Firewall, FirewallError, LogLevel};
 use nullnet_grpc_lib::NullnetGrpcInterface;
-use nullnet_grpc_lib::nullnet_grpc::{Net, Services, ServicesListResponse};
+use nullnet_grpc_lib::nullnet_grpc::{
+    AgentEvent, Net, Services, ServicesListResponse,
+    agent_event::Event as AgentEventKind,
+    AgentBackendTriggerSendFailed, AgentFirewallRulesLoadFailed,
+    AgentServicesListUpdateFailed, AgentServicesListUpdated,
+};
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::collections::HashMap;
 use std::ops::Sub;
@@ -81,7 +86,7 @@ async fn main() -> Result<(), Error> {
     firewall.log_level(LogLevel::Db);
     firewall.data_link(DataLink::Ethernet);
     let firewall_shared = Arc::new(RwLock::new(firewall));
-    set_firewall_rules(&firewall_shared, &firewall_path, true).await?;
+    set_firewall_rules(&firewall_shared, &firewall_path, true, None).await?;
 
     // initialize gRPC connection
     let grpc_server = grpc_init().await?;
@@ -142,14 +147,27 @@ async fn main() -> Result<(), Error> {
                 .await
             {
                 eprintln!("backend_trigger for '{service_name}' port {port} failed: {e}");
-                // allow re-trigger on next observed packet
                 triggers_state_tr.forget(port);
+                let grpc = grpc_server3.clone();
+                let svc = service_name.clone();
+                let err_msg = e.clone();
+                tokio::spawn(async move {
+                    let _ = grpc.report_event(AgentEvent {
+                        event: Some(AgentEventKind::BackendTriggerSendFailed(
+                            AgentBackendTriggerSendFailed {
+                                service_name: svc,
+                                port: u32::from(port),
+                                error_message: err_msg,
+                            },
+                        )),
+                    }).await;
+                });
             }
         }
     });
 
     // watch the file defining rules and update the firewall accordingly
-    set_firewall_rules(&firewall_shared, &firewall_path, false).await?;
+    set_firewall_rules(&firewall_shared, &firewall_path, false, Some(grpc_server.clone())).await?;
 
     Ok(())
 }
@@ -163,10 +181,12 @@ fn print_info(net: Net) {
 }
 
 /// Loads and refreshes firewall rules whenever the corresponding file is updated.
+/// `grpc` is only used in the reload path (watch loop); initial load happens before gRPC is up.
 async fn set_firewall_rules(
     firewall: &Arc<RwLock<Firewall>>,
     firewall_path: &str,
     is_init: bool,
+    grpc: Option<NullnetGrpcInterface>,
 ) -> Result<(), Error> {
     let print_info = |result: &Result<(), FirewallError>, is_init: bool| match result {
         Err(err) => {
@@ -194,6 +214,7 @@ async fn set_firewall_rules(
         }
     }
 
+    let firewall_path_owned = firewall_path.to_string();
     let mut firewall_directory = PathBuf::from(firewall_path);
     firewall_directory.pop();
 
@@ -216,8 +237,22 @@ async fn set_firewall_rules(
             if last_update_time.elapsed().as_millis() > 100 {
                 // ensure file changes are propagated
                 tokio::time::sleep(Duration::from_millis(100)).await;
-                let result = firewall.write().await.set_rules(firewall_path);
+                let result = firewall.write().await.set_rules(&firewall_path_owned);
                 print_info(&result, is_init);
+                if let Err(ref err) = result {
+                    if let Some(ref g) = grpc {
+                        let g = g.clone();
+                        let path = firewall_path_owned.clone();
+                        let error_message = err.to_string();
+                        tokio::spawn(async move {
+                            let _ = g.report_event(AgentEvent {
+                                event: Some(AgentEventKind::FirewallRulesLoadFailed(
+                                    AgentFirewallRulesLoadFailed { path, error_message },
+                                )),
+                            }).await;
+                        });
+                    }
+                }
                 if result.is_ok() && is_init {
                     return Ok(());
                 }
@@ -280,27 +315,48 @@ async fn declare_services(
         }
 
         println!("Declaring services to gRPC server: {services:?}");
+        let num_services = services.services.len() as u32;
 
         // send services to gRPC server; response carries the trigger ports
         // attached to the services we just declared as hosting.
-        let response: ServicesListResponse = grpc_server
-            .services_list(services)
-            .await
-            .handle_err(location!())?;
-
-        let mut port_to_service: HashMap<u16, String> = HashMap::new();
-        for st in response.service_triggers {
-            for port in st.ports {
-                let Ok(port) = u16::try_from(port) else {
-                    eprintln!("server returned invalid trigger port {port}; skipping");
-                    continue;
-                };
-                port_to_service.insert(port, st.service_name.clone());
+        match grpc_server.services_list(services).await {
+            Err(e) => {
+                eprintln!("services_list failed: {e}");
+                let grpc = grpc_server.clone();
+                let error_message = e.clone();
+                tokio::spawn(async move {
+                    let _ = grpc.report_event(AgentEvent {
+                        event: Some(AgentEventKind::ServicesListUpdateFailed(
+                            AgentServicesListUpdateFailed { error_message, num_services },
+                        )),
+                    }).await;
+                });
             }
-        }
-        if config_tx.send(port_to_service).is_err() {
-            // observer task gone; nothing more to do here
-            return Ok(());
+            Ok(response) => {
+                let grpc = grpc_server.clone();
+                tokio::spawn(async move {
+                    let _ = grpc.report_event(AgentEvent {
+                        event: Some(AgentEventKind::ServicesListUpdated(
+                            AgentServicesListUpdated { num_services },
+                        )),
+                    }).await;
+                });
+
+                let mut port_to_service: HashMap<u16, String> = HashMap::new();
+                for st in response.service_triggers {
+                    for port in st.ports {
+                        let Ok(port) = u16::try_from(port) else {
+                            eprintln!("server returned invalid trigger port {port}; skipping");
+                            continue;
+                        };
+                        port_to_service.insert(port, st.service_name.clone());
+                    }
+                }
+                if config_tx.send(port_to_service).is_err() {
+                    // observer task gone; nothing more to do here
+                    return Ok(());
+                }
+            }
         }
 
         // wait before re-declaring services

--- a/members/nullnet-client/src/main.rs
+++ b/members/nullnet-client/src/main.rs
@@ -15,10 +15,9 @@ use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watche
 use nullnet_firewall::{DataLink, Firewall, FirewallError, LogLevel};
 use nullnet_grpc_lib::NullnetGrpcInterface;
 use nullnet_grpc_lib::nullnet_grpc::{
-    AgentEvent, Net, Services,
+    AgentBackendTriggerSendFailed, AgentEvent, AgentFirewallRulesLoadFailed,
+    AgentServicesListUpdateFailed, AgentServicesListUpdated, Net, Services,
     agent_event::Event as AgentEventKind,
-    AgentBackendTriggerSendFailed, AgentFirewallRulesLoadFailed,
-    AgentServicesListUpdateFailed, AgentServicesListUpdated,
 };
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::collections::HashMap;
@@ -153,22 +152,30 @@ async fn main() -> Result<(), Error> {
                 let svc = service_name.clone();
                 let err_msg = e.clone();
                 tokio::spawn(async move {
-                    let _ = grpc.report_event(AgentEvent {
-                        event: Some(AgentEventKind::BackendTriggerSendFailed(
-                            AgentBackendTriggerSendFailed {
-                                service_name: svc,
-                                port: u32::from(port),
-                                error_message: err_msg,
-                            },
-                        )),
-                    }).await;
+                    let _ = grpc
+                        .report_event(AgentEvent {
+                            event: Some(AgentEventKind::BackendTriggerSendFailed(
+                                AgentBackendTriggerSendFailed {
+                                    service_name: svc,
+                                    port: u32::from(port),
+                                    error_message: err_msg,
+                                },
+                            )),
+                        })
+                        .await;
                 });
             }
         }
     });
 
     // watch the file defining rules and update the firewall accordingly
-    set_firewall_rules(&firewall_shared, &firewall_path, false, Some(grpc_server.clone())).await?;
+    set_firewall_rules(
+        &firewall_shared,
+        &firewall_path,
+        false,
+        Some(grpc_server.clone()),
+    )
+    .await?;
 
     Ok(())
 }
@@ -246,11 +253,16 @@ async fn set_firewall_rules(
                         let path = firewall_path_owned.clone();
                         let error_message = err.to_string();
                         tokio::spawn(async move {
-                            let _ = g.report_event(AgentEvent {
-                                event: Some(AgentEventKind::FirewallRulesLoadFailed(
-                                    AgentFirewallRulesLoadFailed { path, error_message },
-                                )),
-                            }).await;
+                            let _ = g
+                                .report_event(AgentEvent {
+                                    event: Some(AgentEventKind::FirewallRulesLoadFailed(
+                                        AgentFirewallRulesLoadFailed {
+                                            path,
+                                            error_message,
+                                        },
+                                    )),
+                                })
+                                .await;
                         });
                     }
                 }
@@ -322,7 +334,8 @@ async fn declare_services(
         // canonical snapshot for change detection (order-independent)
         let mut current = services.services.clone();
         current.sort_by(|a, b| {
-            a.name.cmp(&b.name)
+            a.name
+                .cmp(&b.name)
                 .then(a.stack.cmp(&b.stack))
                 .then(a.port.cmp(&b.port))
                 .then(a.docker_container.cmp(&b.docker_container))
@@ -336,11 +349,16 @@ async fn declare_services(
                 let grpc = grpc_server.clone();
                 let error_message = e.clone();
                 tokio::spawn(async move {
-                    let _ = grpc.report_event(AgentEvent {
-                        event: Some(AgentEventKind::ServicesListUpdateFailed(
-                            AgentServicesListUpdateFailed { error_message, num_services },
-                        )),
-                    }).await;
+                    let _ = grpc
+                        .report_event(AgentEvent {
+                            event: Some(AgentEventKind::ServicesListUpdateFailed(
+                                AgentServicesListUpdateFailed {
+                                    error_message,
+                                    num_services,
+                                },
+                            )),
+                        })
+                        .await;
                 });
             }
             Ok(response) => {
@@ -348,11 +366,13 @@ async fn declare_services(
                     last_declared = current;
                     let grpc = grpc_server.clone();
                     tokio::spawn(async move {
-                        let _ = grpc.report_event(AgentEvent {
-                            event: Some(AgentEventKind::ServicesListUpdated(
-                                AgentServicesListUpdated { num_services },
-                            )),
-                        }).await;
+                        let _ = grpc
+                            .report_event(AgentEvent {
+                                event: Some(AgentEventKind::ServicesListUpdated(
+                                    AgentServicesListUpdated { num_services },
+                                )),
+                            })
+                            .await;
                     });
                 }
 

--- a/members/nullnet-client/src/main.rs
+++ b/members/nullnet-client/src/main.rs
@@ -278,6 +278,7 @@ async fn declare_services(
     grpc_server: NullnetGrpcInterface,
     config_tx: UnboundedSender<HashMap<u16, String>>,
 ) -> Result<(), Error> {
+    let mut last_declared: Vec<nullnet_grpc_lib::nullnet_grpc::Service> = Vec::new();
     loop {
         // read services from file
         let services_toml = tokio::fs::read_to_string("services.toml")
@@ -318,6 +319,15 @@ async fn declare_services(
         println!("Declaring services to gRPC server: {services:?}");
         let num_services = services.services.len() as u32;
 
+        // canonical snapshot for change detection (order-independent)
+        let mut current = services.services.clone();
+        current.sort_by(|a, b| {
+            a.name.cmp(&b.name)
+                .then(a.stack.cmp(&b.stack))
+                .then(a.port.cmp(&b.port))
+                .then(a.docker_container.cmp(&b.docker_container))
+        });
+
         // send services to gRPC server; response carries the trigger ports
         // attached to the services we just declared as hosting.
         match grpc_server.services_list(services).await {
@@ -334,14 +344,17 @@ async fn declare_services(
                 });
             }
             Ok(response) => {
-                let grpc = grpc_server.clone();
-                tokio::spawn(async move {
-                    let _ = grpc.report_event(AgentEvent {
-                        event: Some(AgentEventKind::ServicesListUpdated(
-                            AgentServicesListUpdated { num_services },
-                        )),
-                    }).await;
-                });
+                if current != last_declared {
+                    last_declared = current;
+                    let grpc = grpc_server.clone();
+                    tokio::spawn(async move {
+                        let _ = grpc.report_event(AgentEvent {
+                            event: Some(AgentEventKind::ServicesListUpdated(
+                                AgentServicesListUpdated { num_services },
+                            )),
+                        }).await;
+                    });
+                }
 
                 let mut port_to_service: HashMap<u16, String> = HashMap::new();
                 for st in response.service_triggers {

--- a/members/nullnet-grpc-lib/proto/nullnet_grpc.proto
+++ b/members/nullnet-grpc-lib/proto/nullnet_grpc.proto
@@ -24,6 +24,9 @@ service NullnetGrpc {
 
   // Backend trigger — for service-to-service chains that do not involve the proxy.
   rpc BackendTrigger(BackendTriggerRequest) returns (Empty);
+
+  // Report an event from a client or proxy agent back to the server.
+  rpc ReportEvent(AgentEvent) returns (Empty);
 }
 
 // TAP-based clients ---------------------------------------------------------------------------------------------------
@@ -142,3 +145,58 @@ message BackendTriggerRequest {
 // Misc ----------------------------------------------------------------------------------------------------------------
 
 message Empty { }
+
+// Agent event report — sent from nullnet-client or nullnet-proxy to the server.
+message AgentEvent {
+  oneof event {
+    // Client error events
+    AgentVxlanSetupFailed       vxlan_setup_failed       = 1;
+    AgentVlanSetupFailed        vlan_setup_failed        = 2;
+    AgentVxlanTeardownFailed    vxlan_teardown_failed    = 3;
+    AgentVlanTeardownFailed     vlan_teardown_failed     = 4;
+    AgentDnatInstallFailed      dnat_install_failed      = 5;
+    AgentDnatRemovalFailed      dnat_removal_failed      = 6;
+    AgentHostMappingFailed      host_mapping_failed      = 7;
+    AgentControlChannelClosed   control_channel_closed   = 8;
+    AgentControlChannelAckFailed control_channel_ack_failed = 9;
+    AgentServicesListUpdateFailed services_list_update_failed = 10;
+    AgentBackendTriggerSendFailed backend_trigger_send_failed = 11;
+    AgentFirewallRulesLoadFailed  firewall_rules_load_failed  = 12;
+    // Client info events
+    AgentVxlanSetupCompleted      vxlan_setup_completed      = 13;
+    AgentVlanSetupCompleted       vlan_setup_completed       = 14;
+    AgentControlChannelEstablished control_channel_established = 15;
+    AgentServicesListUpdated      services_list_updated      = 16;
+    // Proxy error events
+    AgentUpstreamLookupFailed     upstream_lookup_failed     = 17;
+    AgentProxyRequestMissingHost  proxy_request_missing_host = 18;
+    AgentProxyRequestInvalidHost  proxy_request_invalid_host = 19;
+    AgentUpstreamIpParseFailed    upstream_ip_parse_failed   = 20;
+    AgentProxyClientNotInet       proxy_client_not_inet      = 21;
+    // Proxy info events
+    AgentProxyRequestRouted       proxy_request_routed       = 22;
+  }
+}
+
+message AgentVxlanSetupFailed       { uint32 vxlan_id = 1; string ns_name = 2; int32 error_code = 3; }
+message AgentVlanSetupFailed        { uint32 vlan_id = 1; string local_veth = 2; string error_reason = 3; }
+message AgentVxlanTeardownFailed    { uint32 vxlan_id = 1; string ns_name = 2; int32 error_code = 3; }
+message AgentVlanTeardownFailed     { uint32 vlan_id = 1; string error_reason = 2; }
+message AgentDnatInstallFailed      { uint32 port = 1; string overlay_ip = 2; }
+message AgentDnatRemovalFailed      { uint32 port = 1; string overlay_ip = 2; }
+message AgentHostMappingFailed      { string hostname = 1; string ip = 2; optional string docker_container = 3; }
+message AgentControlChannelClosed   {}
+message AgentControlChannelAckFailed { string msg_id = 1; string message_type = 2; }
+message AgentServicesListUpdateFailed { string error_message = 1; uint32 num_services = 2; }
+message AgentBackendTriggerSendFailed { string service_name = 1; uint32 port = 2; string error_message = 3; }
+message AgentFirewallRulesLoadFailed  { string path = 1; string error_message = 2; }
+message AgentVxlanSetupCompleted    { uint32 vxlan_id = 1; string ns_name = 2; }
+message AgentVlanSetupCompleted     { uint32 vlan_id = 1; }
+message AgentControlChannelEstablished {}
+message AgentServicesListUpdated    { uint32 num_services = 1; }
+message AgentUpstreamLookupFailed   { string service_name = 1; string client_ip = 2; string error_message = 3; }
+message AgentProxyRequestMissingHost { string client_ip = 1; }
+message AgentProxyRequestInvalidHost { string client_ip = 1; }
+message AgentUpstreamIpParseFailed  { string raw_ip = 1; string service_name = 2; }
+message AgentProxyClientNotInet     { string address_family = 1; }
+message AgentProxyRequestRouted     { string service_name = 1; string client_ip = 2; string upstream_ip = 3; uint64 latency_ms = 4; }

--- a/members/nullnet-grpc-lib/src/lib.rs
+++ b/members/nullnet-grpc-lib/src/lib.rs
@@ -2,7 +2,7 @@ mod proto;
 
 use crate::nullnet_grpc::nullnet_grpc_client::NullnetGrpcClient;
 use crate::nullnet_grpc::{
-    BackendTriggerRequest, Empty, MsgId, NetMessage, NetType, ProxyRequest, Services,
+    AgentEvent, BackendTriggerRequest, Empty, MsgId, NetMessage, NetType, ProxyRequest, Services,
     ServicesListResponse, Upstream,
 };
 pub use proto::*;
@@ -98,6 +98,16 @@ impl NullnetGrpcInterface {
         self.client
             .clone()
             .backend_trigger(Request::new(BackendTriggerRequest { service_name, port }))
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    #[allow(clippy::missing_errors_doc)]
+    pub async fn report_event(&self, event: AgentEvent) -> Result<(), String> {
+        self.client
+            .clone()
+            .report_event(Request::new(event))
             .await
             .map(|_| ())
             .map_err(|e| e.to_string())

--- a/members/nullnet-grpc-lib/src/proto/nullnet_grpc.rs
+++ b/members/nullnet-grpc-lib/src/proto/nullnet_grpc.rs
@@ -156,6 +156,219 @@ pub struct BackendTriggerRequest {
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Empty {}
+/// Agent event report — sent from nullnet-client or nullnet-proxy to the server.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentEvent {
+    #[prost(
+        oneof = "agent_event::Event",
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22"
+    )]
+    pub event: ::core::option::Option<agent_event::Event>,
+}
+/// Nested message and enum types in `AgentEvent`.
+pub mod agent_event {
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Event {
+        /// Client error events
+        #[prost(message, tag = "1")]
+        VxlanSetupFailed(super::AgentVxlanSetupFailed),
+        #[prost(message, tag = "2")]
+        VlanSetupFailed(super::AgentVlanSetupFailed),
+        #[prost(message, tag = "3")]
+        VxlanTeardownFailed(super::AgentVxlanTeardownFailed),
+        #[prost(message, tag = "4")]
+        VlanTeardownFailed(super::AgentVlanTeardownFailed),
+        #[prost(message, tag = "5")]
+        DnatInstallFailed(super::AgentDnatInstallFailed),
+        #[prost(message, tag = "6")]
+        DnatRemovalFailed(super::AgentDnatRemovalFailed),
+        #[prost(message, tag = "7")]
+        HostMappingFailed(super::AgentHostMappingFailed),
+        #[prost(message, tag = "8")]
+        ControlChannelClosed(super::AgentControlChannelClosed),
+        #[prost(message, tag = "9")]
+        ControlChannelAckFailed(super::AgentControlChannelAckFailed),
+        #[prost(message, tag = "10")]
+        ServicesListUpdateFailed(super::AgentServicesListUpdateFailed),
+        #[prost(message, tag = "11")]
+        BackendTriggerSendFailed(super::AgentBackendTriggerSendFailed),
+        #[prost(message, tag = "12")]
+        FirewallRulesLoadFailed(super::AgentFirewallRulesLoadFailed),
+        /// Client info events
+        #[prost(message, tag = "13")]
+        VxlanSetupCompleted(super::AgentVxlanSetupCompleted),
+        #[prost(message, tag = "14")]
+        VlanSetupCompleted(super::AgentVlanSetupCompleted),
+        #[prost(message, tag = "15")]
+        ControlChannelEstablished(super::AgentControlChannelEstablished),
+        #[prost(message, tag = "16")]
+        ServicesListUpdated(super::AgentServicesListUpdated),
+        /// Proxy error events
+        #[prost(message, tag = "17")]
+        UpstreamLookupFailed(super::AgentUpstreamLookupFailed),
+        #[prost(message, tag = "18")]
+        ProxyRequestMissingHost(super::AgentProxyRequestMissingHost),
+        #[prost(message, tag = "19")]
+        ProxyRequestInvalidHost(super::AgentProxyRequestInvalidHost),
+        #[prost(message, tag = "20")]
+        UpstreamIpParseFailed(super::AgentUpstreamIpParseFailed),
+        #[prost(message, tag = "21")]
+        ProxyClientNotInet(super::AgentProxyClientNotInet),
+        /// Proxy info events
+        #[prost(message, tag = "22")]
+        ProxyRequestRouted(super::AgentProxyRequestRouted),
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentVxlanSetupFailed {
+    #[prost(uint32, tag = "1")]
+    pub vxlan_id: u32,
+    #[prost(string, tag = "2")]
+    pub ns_name: ::prost::alloc::string::String,
+    #[prost(int32, tag = "3")]
+    pub error_code: i32,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentVlanSetupFailed {
+    #[prost(uint32, tag = "1")]
+    pub vlan_id: u32,
+    #[prost(string, tag = "2")]
+    pub local_veth: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub error_reason: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentVxlanTeardownFailed {
+    #[prost(uint32, tag = "1")]
+    pub vxlan_id: u32,
+    #[prost(string, tag = "2")]
+    pub ns_name: ::prost::alloc::string::String,
+    #[prost(int32, tag = "3")]
+    pub error_code: i32,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentVlanTeardownFailed {
+    #[prost(uint32, tag = "1")]
+    pub vlan_id: u32,
+    #[prost(string, tag = "2")]
+    pub error_reason: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentDnatInstallFailed {
+    #[prost(uint32, tag = "1")]
+    pub port: u32,
+    #[prost(string, tag = "2")]
+    pub overlay_ip: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentDnatRemovalFailed {
+    #[prost(uint32, tag = "1")]
+    pub port: u32,
+    #[prost(string, tag = "2")]
+    pub overlay_ip: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentHostMappingFailed {
+    #[prost(string, tag = "1")]
+    pub hostname: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub ip: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "3")]
+    pub docker_container: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentControlChannelClosed {}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentControlChannelAckFailed {
+    #[prost(string, tag = "1")]
+    pub msg_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub message_type: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentServicesListUpdateFailed {
+    #[prost(string, tag = "1")]
+    pub error_message: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub num_services: u32,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentBackendTriggerSendFailed {
+    #[prost(string, tag = "1")]
+    pub service_name: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "2")]
+    pub port: u32,
+    #[prost(string, tag = "3")]
+    pub error_message: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentFirewallRulesLoadFailed {
+    #[prost(string, tag = "1")]
+    pub path: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub error_message: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentVxlanSetupCompleted {
+    #[prost(uint32, tag = "1")]
+    pub vxlan_id: u32,
+    #[prost(string, tag = "2")]
+    pub ns_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentVlanSetupCompleted {
+    #[prost(uint32, tag = "1")]
+    pub vlan_id: u32,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentControlChannelEstablished {}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentServicesListUpdated {
+    #[prost(uint32, tag = "1")]
+    pub num_services: u32,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentUpstreamLookupFailed {
+    #[prost(string, tag = "1")]
+    pub service_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub client_ip: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub error_message: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentProxyRequestMissingHost {
+    #[prost(string, tag = "1")]
+    pub client_ip: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentProxyRequestInvalidHost {
+    #[prost(string, tag = "1")]
+    pub client_ip: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentUpstreamIpParseFailed {
+    #[prost(string, tag = "1")]
+    pub raw_ip: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub service_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentProxyClientNotInet {
+    #[prost(string, tag = "1")]
+    pub address_family: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentProxyRequestRouted {
+    #[prost(string, tag = "1")]
+    pub service_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub client_ip: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub upstream_ip: ::prost::alloc::string::String,
+    #[prost(uint64, tag = "4")]
+    pub latency_ms: u64,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Net {
@@ -390,6 +603,28 @@ pub mod nullnet_grpc_client {
                 .insert(GrpcMethod::new("nullnet_grpc.NullnetGrpc", "BackendTrigger"));
             self.inner.unary(req, path, codec).await
         }
+        /// Report an event from a client or proxy agent back to the server.
+        pub async fn report_event(
+            &mut self,
+            request: impl tonic::IntoRequest<super::AgentEvent>,
+        ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/nullnet_grpc.NullnetGrpc/ReportEvent",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("nullnet_grpc.NullnetGrpc", "ReportEvent"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -442,6 +677,11 @@ pub mod nullnet_grpc_server {
         async fn backend_trigger(
             &self,
             request: tonic::Request<super::BackendTriggerRequest>,
+        ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status>;
+        /// Report an event from a client or proxy agent back to the server.
+        async fn report_event(
+            &self,
+            request: tonic::Request<super::AgentEvent>,
         ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status>;
     }
     #[derive(Debug)]
@@ -723,6 +963,49 @@ pub mod nullnet_grpc_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = BackendTriggerSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/nullnet_grpc.NullnetGrpc/ReportEvent" => {
+                    #[allow(non_camel_case_types)]
+                    struct ReportEventSvc<T: NullnetGrpc>(pub Arc<T>);
+                    impl<T: NullnetGrpc> tonic::server::UnaryService<super::AgentEvent>
+                    for ReportEventSvc<T> {
+                        type Response = super::Empty;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::AgentEvent>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as NullnetGrpc>::report_event(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ReportEventSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/members/nullnet-proxy/src/main.rs
+++ b/members/nullnet-proxy/src/main.rs
@@ -3,7 +3,12 @@ mod nullnet_proxy;
 
 use crate::nullnet_proxy::NullnetProxy;
 use async_trait::async_trait;
-use nullnet_grpc_lib::nullnet_grpc::ProxyRequest;
+use nullnet_grpc_lib::nullnet_grpc::{
+    AgentEvent, ProxyRequest,
+    agent_event::Event as AgentEventKind,
+    AgentProxyClientNotInet, AgentProxyRequestInvalidHost, AgentProxyRequestMissingHost,
+    AgentProxyRequestRouted, AgentUpstreamLookupFailed,
+};
 use nullnet_liberror::{ErrorHandler, Location, location};
 use pingora_core::server::Server;
 use pingora_core::upstreams::peer::HttpPeer;
@@ -28,57 +33,125 @@ impl ProxyHttp for NullnetProxy {
 
         let init_t = Instant::now();
 
-        let host_header = session
-            .get_header("host")
-            .ok_or("No host header in request")
-            .handle_err(location!())
-            .map_err(|_| Error::explain(ErrorType::BindError, "No host header in request"))?;
-        let host_str = host_header
-            .to_str()
-            .handle_err(location!())
-            .map_err(|_| Error::explain(ErrorType::BindError, "Invalid host header"))?;
+        // Extract client IP early so we can include it in error events
+        let client_ip_opt = session
+            .client_addr()
+            .and_then(|a| a.as_inet())
+            .map(|a| a.ip().to_string());
+        let client_ip_for_events = client_ip_opt.clone().unwrap_or_default();
+
+        let host_header = match session.get_header("host") {
+            Some(h) => h,
+            None => {
+                let server = self.server.clone();
+                let cip = client_ip_for_events.clone();
+                tokio::spawn(async move {
+                    let _ = server.report_event(AgentEvent {
+                        event: Some(AgentEventKind::ProxyRequestMissingHost(
+                            AgentProxyRequestMissingHost { client_ip: cip },
+                        )),
+                    }).await;
+                });
+                return Err(Error::explain(ErrorType::BindError, "No host header in request"));
+            }
+        };
+        let host_str = match host_header.to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                let server = self.server.clone();
+                let cip = client_ip_for_events.clone();
+                tokio::spawn(async move {
+                    let _ = server.report_event(AgentEvent {
+                        event: Some(AgentEventKind::ProxyRequestInvalidHost(
+                            AgentProxyRequestInvalidHost { client_ip: cip },
+                        )),
+                    }).await;
+                });
+                return Err(Error::explain(ErrorType::BindError, "Invalid host header"));
+            }
+        };
         let url = host_str
             .strip_suffix(&format!(":{PROXY_PORT}"))
             .unwrap_or(host_str);
-        let client_ip = session
-            .client_addr()
-            .ok_or("Client address not found in session")
-            .handle_err(location!())
-            .map_err(|_| {
-                Error::explain(ErrorType::BindError, "Client address not found in session")
-            })?
-            .as_inet()
-            .ok_or("Client address is not an Inet address")
-            .handle_err(location!())
-            .map_err(|_| {
-                Error::explain(
-                    ErrorType::BindError,
-                    "Client address is not an Inet address",
-                )
-            })?
-            .ip()
-            .to_string();
+
+        let client_ip = match session.client_addr() {
+            None => {
+                let server = self.server.clone();
+                tokio::spawn(async move {
+                    let _ = server.report_event(AgentEvent {
+                        event: Some(AgentEventKind::ProxyClientNotInet(
+                            AgentProxyClientNotInet { address_family: "none".to_string() },
+                        )),
+                    }).await;
+                });
+                return Err(Error::explain(ErrorType::BindError, "Client address not found in session"));
+            }
+            Some(addr) => match addr.as_inet() {
+                None => {
+                    let server = self.server.clone();
+                    tokio::spawn(async move {
+                        let _ = server.report_event(AgentEvent {
+                            event: Some(AgentEventKind::ProxyClientNotInet(
+                                AgentProxyClientNotInet { address_family: "non-inet".to_string() },
+                            )),
+                        }).await;
+                    });
+                    return Err(Error::explain(ErrorType::BindError, "Client address is not an Inet address"));
+                }
+                Some(inet) => inet.ip().to_string(),
+            },
+        };
 
         let service_name = url.to_string();
         let proxy_req = ProxyRequest {
-            client_ip,
-            service_name,
+            client_ip: client_ip.clone(),
+            service_name: service_name.clone(),
         };
         println!("{proxy_req:?}");
-        let upstream = self
-            .get_or_add_upstream(proxy_req)
-            .await
-            .map_err(|_| Error::explain(ErrorType::BindError, "Failed to retrieve upstream"))?;
+        let upstream = match self.get_or_add_upstream(proxy_req).await {
+            Ok(u) => u,
+            Err(_) => {
+                let server = self.server.clone();
+                let cip = client_ip.clone();
+                let svc = service_name.clone();
+                tokio::spawn(async move {
+                    let _ = server.report_event(AgentEvent {
+                        event: Some(AgentEventKind::UpstreamLookupFailed(
+                            AgentUpstreamLookupFailed {
+                                service_name: svc,
+                                client_ip: cip,
+                                error_message: "upstream lookup failed".to_string(),
+                            },
+                        )),
+                    }).await;
+                });
+                return Err(Error::explain(ErrorType::BindError, "Failed to retrieve upstream"));
+            }
+        };
         println!("upstream: {upstream}\n");
 
-        let peer = Box::new(HttpPeer::new(upstream, false, String::new()));
+        let latency_ms = init_t.elapsed().as_millis() as u64;
+        let server = self.server.clone();
+        let svc = service_name.clone();
+        let cip = client_ip.clone();
+        let uip = upstream.ip().to_string();
+        tokio::spawn(async move {
+            let _ = server.report_event(AgentEvent {
+                event: Some(AgentEventKind::ProxyRequestRouted(AgentProxyRequestRouted {
+                    service_name: svc,
+                    client_ip: cip,
+                    upstream_ip: uip,
+                    latency_ms,
+                })),
+            }).await;
+        });
 
         println!(
             "TOTAL VLANS SETUP TIME: {} ms\n",
-            init_t.elapsed().as_millis()
+            latency_ms
         );
 
-        Ok(peer)
+        Ok(Box::new(HttpPeer::new(upstream, false, String::new())))
     }
 }
 

--- a/members/nullnet-proxy/src/main.rs
+++ b/members/nullnet-proxy/src/main.rs
@@ -4,10 +4,9 @@ mod nullnet_proxy;
 use crate::nullnet_proxy::NullnetProxy;
 use async_trait::async_trait;
 use nullnet_grpc_lib::nullnet_grpc::{
-    AgentEvent, ProxyRequest,
+    AgentEvent, AgentProxyClientNotInet, AgentProxyRequestInvalidHost,
+    AgentProxyRequestMissingHost, AgentProxyRequestRouted, AgentUpstreamLookupFailed, ProxyRequest,
     agent_event::Event as AgentEventKind,
-    AgentProxyClientNotInet, AgentProxyRequestInvalidHost, AgentProxyRequestMissingHost,
-    AgentProxyRequestRouted, AgentUpstreamLookupFailed,
 };
 use nullnet_liberror::{ErrorHandler, Location, location};
 use pingora_core::server::Server;
@@ -46,13 +45,18 @@ impl ProxyHttp for NullnetProxy {
                 let server = self.server.clone();
                 let cip = client_ip_for_events.clone();
                 tokio::spawn(async move {
-                    let _ = server.report_event(AgentEvent {
-                        event: Some(AgentEventKind::ProxyRequestMissingHost(
-                            AgentProxyRequestMissingHost { client_ip: cip },
-                        )),
-                    }).await;
+                    let _ = server
+                        .report_event(AgentEvent {
+                            event: Some(AgentEventKind::ProxyRequestMissingHost(
+                                AgentProxyRequestMissingHost { client_ip: cip },
+                            )),
+                        })
+                        .await;
                 });
-                return Err(Error::explain(ErrorType::BindError, "No host header in request"));
+                return Err(Error::explain(
+                    ErrorType::BindError,
+                    "No host header in request",
+                ));
             }
         };
         let host_str = match host_header.to_str() {
@@ -61,11 +65,13 @@ impl ProxyHttp for NullnetProxy {
                 let server = self.server.clone();
                 let cip = client_ip_for_events.clone();
                 tokio::spawn(async move {
-                    let _ = server.report_event(AgentEvent {
-                        event: Some(AgentEventKind::ProxyRequestInvalidHost(
-                            AgentProxyRequestInvalidHost { client_ip: cip },
-                        )),
-                    }).await;
+                    let _ = server
+                        .report_event(AgentEvent {
+                            event: Some(AgentEventKind::ProxyRequestInvalidHost(
+                                AgentProxyRequestInvalidHost { client_ip: cip },
+                            )),
+                        })
+                        .await;
                 });
                 return Err(Error::explain(ErrorType::BindError, "Invalid host header"));
             }
@@ -78,25 +84,39 @@ impl ProxyHttp for NullnetProxy {
             None => {
                 let server = self.server.clone();
                 tokio::spawn(async move {
-                    let _ = server.report_event(AgentEvent {
-                        event: Some(AgentEventKind::ProxyClientNotInet(
-                            AgentProxyClientNotInet { address_family: "none".to_string() },
-                        )),
-                    }).await;
+                    let _ = server
+                        .report_event(AgentEvent {
+                            event: Some(AgentEventKind::ProxyClientNotInet(
+                                AgentProxyClientNotInet {
+                                    address_family: "none".to_string(),
+                                },
+                            )),
+                        })
+                        .await;
                 });
-                return Err(Error::explain(ErrorType::BindError, "Client address not found in session"));
+                return Err(Error::explain(
+                    ErrorType::BindError,
+                    "Client address not found in session",
+                ));
             }
             Some(addr) => match addr.as_inet() {
                 None => {
                     let server = self.server.clone();
                     tokio::spawn(async move {
-                        let _ = server.report_event(AgentEvent {
-                            event: Some(AgentEventKind::ProxyClientNotInet(
-                                AgentProxyClientNotInet { address_family: "non-inet".to_string() },
-                            )),
-                        }).await;
+                        let _ = server
+                            .report_event(AgentEvent {
+                                event: Some(AgentEventKind::ProxyClientNotInet(
+                                    AgentProxyClientNotInet {
+                                        address_family: "non-inet".to_string(),
+                                    },
+                                )),
+                            })
+                            .await;
                     });
-                    return Err(Error::explain(ErrorType::BindError, "Client address is not an Inet address"));
+                    return Err(Error::explain(
+                        ErrorType::BindError,
+                        "Client address is not an Inet address",
+                    ));
                 }
                 Some(inet) => inet.ip().to_string(),
             },
@@ -115,17 +135,22 @@ impl ProxyHttp for NullnetProxy {
                 let cip = client_ip.clone();
                 let svc = service_name.clone();
                 tokio::spawn(async move {
-                    let _ = server.report_event(AgentEvent {
-                        event: Some(AgentEventKind::UpstreamLookupFailed(
-                            AgentUpstreamLookupFailed {
-                                service_name: svc,
-                                client_ip: cip,
-                                error_message: "upstream lookup failed".to_string(),
-                            },
-                        )),
-                    }).await;
+                    let _ = server
+                        .report_event(AgentEvent {
+                            event: Some(AgentEventKind::UpstreamLookupFailed(
+                                AgentUpstreamLookupFailed {
+                                    service_name: svc,
+                                    client_ip: cip,
+                                    error_message: "upstream lookup failed".to_string(),
+                                },
+                            )),
+                        })
+                        .await;
                 });
-                return Err(Error::explain(ErrorType::BindError, "Failed to retrieve upstream"));
+                return Err(Error::explain(
+                    ErrorType::BindError,
+                    "Failed to retrieve upstream",
+                ));
             }
         };
         println!("upstream: {upstream}\n");
@@ -136,20 +161,21 @@ impl ProxyHttp for NullnetProxy {
         let cip = client_ip.clone();
         let uip = upstream.ip().to_string();
         tokio::spawn(async move {
-            let _ = server.report_event(AgentEvent {
-                event: Some(AgentEventKind::ProxyRequestRouted(AgentProxyRequestRouted {
-                    service_name: svc,
-                    client_ip: cip,
-                    upstream_ip: uip,
-                    latency_ms,
-                })),
-            }).await;
+            let _ = server
+                .report_event(AgentEvent {
+                    event: Some(AgentEventKind::ProxyRequestRouted(
+                        AgentProxyRequestRouted {
+                            service_name: svc,
+                            client_ip: cip,
+                            upstream_ip: uip,
+                            latency_ms,
+                        },
+                    )),
+                })
+                .await;
         });
 
-        println!(
-            "TOTAL VLANS SETUP TIME: {} ms\n",
-            latency_ms
-        );
+        println!("TOTAL VLANS SETUP TIME: {} ms\n", latency_ms);
 
         Ok(Box::new(HttpPeer::new(upstream, false, String::new())))
     }

--- a/members/nullnet-proxy/src/nullnet_proxy.rs
+++ b/members/nullnet-proxy/src/nullnet_proxy.rs
@@ -1,12 +1,11 @@
 use crate::env::{CONTROL_SERVICE_ADDR, CONTROL_SERVICE_PORT};
 use nullnet_grpc_lib::NullnetGrpcInterface;
-use nullnet_grpc_lib::nullnet_grpc::ProxyRequest;
+use nullnet_grpc_lib::nullnet_grpc::{AgentEvent, AgentUpstreamIpParseFailed, ProxyRequest, agent_event::Event as AgentEventKind};
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::net::{IpAddr, SocketAddr};
 
 pub struct NullnetProxy {
-    /// gRPC interface to Nullnet control service
-    server: NullnetGrpcInterface,
+    pub(crate) server: NullnetGrpcInterface,
 }
 
 impl NullnetProxy {
@@ -24,9 +23,22 @@ impl NullnetProxy {
     pub async fn get_or_add_upstream(&self, proxy_req: ProxyRequest) -> Result<SocketAddr, Error> {
         println!("requesting new upstream...");
 
+        let service_name = proxy_req.service_name.clone();
         let response = self.server.proxy(proxy_req).await.handle_err(location!())?;
 
-        let veth_ip: IpAddr = response.ip.parse().handle_err(location!())?;
+        let raw_ip = response.ip.clone();
+        let veth_ip: IpAddr = response.ip.parse().handle_err(location!()).inspect_err(|_| {
+            let server = self.server.clone();
+            let raw = raw_ip.clone();
+            let svc = service_name.clone();
+            tokio::spawn(async move {
+                let _ = server.report_event(AgentEvent {
+                    event: Some(AgentEventKind::UpstreamIpParseFailed(
+                        AgentUpstreamIpParseFailed { raw_ip: raw, service_name: svc },
+                    )),
+                }).await;
+            });
+        })?;
         let host_port = u16::try_from(response.port).handle_err(location!())?;
         let upstream = SocketAddr::new(veth_ip, host_port);
 

--- a/members/nullnet-proxy/src/nullnet_proxy.rs
+++ b/members/nullnet-proxy/src/nullnet_proxy.rs
@@ -1,6 +1,8 @@
 use crate::env::{CONTROL_SERVICE_ADDR, CONTROL_SERVICE_PORT};
 use nullnet_grpc_lib::NullnetGrpcInterface;
-use nullnet_grpc_lib::nullnet_grpc::{AgentEvent, AgentUpstreamIpParseFailed, ProxyRequest, agent_event::Event as AgentEventKind};
+use nullnet_grpc_lib::nullnet_grpc::{
+    AgentEvent, AgentUpstreamIpParseFailed, ProxyRequest, agent_event::Event as AgentEventKind,
+};
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::net::{IpAddr, SocketAddr};
 
@@ -27,18 +29,27 @@ impl NullnetProxy {
         let response = self.server.proxy(proxy_req).await.handle_err(location!())?;
 
         let raw_ip = response.ip.clone();
-        let veth_ip: IpAddr = response.ip.parse().handle_err(location!()).inspect_err(|_| {
-            let server = self.server.clone();
-            let raw = raw_ip.clone();
-            let svc = service_name.clone();
-            tokio::spawn(async move {
-                let _ = server.report_event(AgentEvent {
-                    event: Some(AgentEventKind::UpstreamIpParseFailed(
-                        AgentUpstreamIpParseFailed { raw_ip: raw, service_name: svc },
-                    )),
-                }).await;
-            });
-        })?;
+        let veth_ip: IpAddr = response
+            .ip
+            .parse()
+            .handle_err(location!())
+            .inspect_err(|_| {
+                let server = self.server.clone();
+                let raw = raw_ip.clone();
+                let svc = service_name.clone();
+                tokio::spawn(async move {
+                    let _ = server
+                        .report_event(AgentEvent {
+                            event: Some(AgentEventKind::UpstreamIpParseFailed(
+                                AgentUpstreamIpParseFailed {
+                                    raw_ip: raw,
+                                    service_name: svc,
+                                },
+                            )),
+                        })
+                        .await;
+                });
+            })?;
         let host_port = u16::try_from(response.port).handle_err(location!())?;
         let upstream = SocketAddr::new(veth_ip, host_port);
 

--- a/members/nullnet-server/Cargo.toml
+++ b/members/nullnet-server/Cargo.toml
@@ -12,7 +12,9 @@ prost.workspace = true
 tonic-prost.workspace = true
 nullnet-liberror.workspace = true
 nullnet-grpc-lib.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "fs", "sync"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+futures = "0.3"
 ctrlc = { version = "3.5.2", features = ["termination"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/members/nullnet-server/src/events.rs
+++ b/members/nullnet-server/src/events.rs
@@ -66,6 +66,55 @@ pub(crate) enum Event {
         stack: String,
         timestamp: u64,
     },
+    ConfigStackRemoved {
+        stack: String,
+        timestamp: u64,
+    },
+    AllReplicasRemoved {
+        service: String,
+        stack: String,
+        ip: String,
+        timestamp: u64,
+    },
+    ServiceReachabilityToggled {
+        service: String,
+        stack: String,
+        reachable: bool,
+        timestamp: u64,
+    },
+    ProxyClientTimedOut {
+        service: String,
+        client_ip: String,
+        timestamp: u64,
+    },
+    StickySessionReused {
+        service: String,
+        client_ip: String,
+        proxy_ip: String,
+        timestamp: u64,
+    },
+    MaxNetworksLimitEnforced {
+        service: String,
+        proxy_ip: String,
+        net_id: u32,
+        limit: u32,
+        timestamp: u64,
+    },
+    NetIdPoolExhausted {
+        service: String,
+        client_ip: String,
+        timestamp: u64,
+    },
+    ProxyChainSetupFailed {
+        service: String,
+        client_ip: String,
+        timestamp: u64,
+    },
+    BackendTriggerSetupBailed {
+        service: String,
+        port: u16,
+        timestamp: u64,
+    },
 }
 
 impl Event {
@@ -81,6 +130,15 @@ impl Event {
             Self::SessionCreated { .. } => "session_created",
             Self::SessionTornDown { .. } => "session_torn_down",
             Self::ConfigReloaded { .. } => "config_reloaded",
+            Self::ConfigStackRemoved { .. } => "config_stack_removed",
+            Self::AllReplicasRemoved { .. } => "all_replicas_removed",
+            Self::ServiceReachabilityToggled { .. } => "service_reachability_toggled",
+            Self::ProxyClientTimedOut { .. } => "proxy_client_timed_out",
+            Self::StickySessionReused { .. } => "sticky_session_reused",
+            Self::MaxNetworksLimitEnforced { .. } => "max_networks_limit_enforced",
+            Self::NetIdPoolExhausted { .. } => "net_id_pool_exhausted",
+            Self::ProxyChainSetupFailed { .. } => "proxy_chain_setup_failed",
+            Self::BackendTriggerSetupBailed { .. } => "backend_trigger_setup_bailed",
         }
     }
 
@@ -161,6 +219,95 @@ impl Event {
     pub(crate) fn config_reloaded(stack: String) -> Self {
         Self::ConfigReloaded {
             stack,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn config_stack_removed(stack: String) -> Self {
+        Self::ConfigStackRemoved {
+            stack,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn all_replicas_removed(service: String, stack: String, ip: String) -> Self {
+        Self::AllReplicasRemoved {
+            service,
+            stack,
+            ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn service_reachability_toggled(
+        service: String,
+        stack: String,
+        reachable: bool,
+    ) -> Self {
+        Self::ServiceReachabilityToggled {
+            service,
+            stack,
+            reachable,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn proxy_client_timed_out(service: String, client_ip: String) -> Self {
+        Self::ProxyClientTimedOut {
+            service,
+            client_ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn sticky_session_reused(
+        service: String,
+        client_ip: String,
+        proxy_ip: String,
+    ) -> Self {
+        Self::StickySessionReused {
+            service,
+            client_ip,
+            proxy_ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn max_networks_limit_enforced(
+        service: String,
+        proxy_ip: String,
+        net_id: u32,
+        limit: u32,
+    ) -> Self {
+        Self::MaxNetworksLimitEnforced {
+            service,
+            proxy_ip,
+            net_id,
+            limit,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn net_id_pool_exhausted(service: String, client_ip: String) -> Self {
+        Self::NetIdPoolExhausted {
+            service,
+            client_ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn proxy_chain_setup_failed(service: String, client_ip: String) -> Self {
+        Self::ProxyChainSetupFailed {
+            service,
+            client_ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn backend_trigger_setup_bailed(service: String, port: u16) -> Self {
+        Self::BackendTriggerSetupBailed {
+            service,
+            port,
             timestamp: now_secs(),
         }
     }

--- a/members/nullnet-server/src/events.rs
+++ b/members/nullnet-server/src/events.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, broadcast};
 
 fn now_secs() -> u64 {
@@ -10,6 +10,23 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Severity {
+    Info,
+    Warning,
+    Error,
+}
+
+/// Wraps an event with its severity for serialization. Produces a flat JSON
+/// object: `{"type":"...","severity":"...","field":...}`.
+#[derive(Serialize)]
+pub(crate) struct EventEnvelope<'a> {
+    pub(crate) severity: Severity,
+    #[serde(flatten)]
+    pub(crate) event: &'a Event,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -115,6 +132,123 @@ pub(crate) enum Event {
         port: u16,
         timestamp: u64,
     },
+
+    // --- Client error events ---
+    VxlanSetupFailed {
+        vxlan_id: u32,
+        ns_name: String,
+        error_code: i32,
+        timestamp: u64,
+    },
+    VlanSetupFailed {
+        vlan_id: u16,
+        local_veth: String,
+        error_reason: String,
+        timestamp: u64,
+    },
+    VxlanTeardownFailed {
+        vxlan_id: u32,
+        ns_name: String,
+        error_code: i32,
+        timestamp: u64,
+    },
+    VlanTeardownFailed {
+        vlan_id: u16,
+        error_reason: String,
+        timestamp: u64,
+    },
+    DnatInstallFailed {
+        port: u16,
+        overlay_ip: String,
+        timestamp: u64,
+    },
+    DnatRemovalFailed {
+        port: u16,
+        overlay_ip: String,
+        timestamp: u64,
+    },
+    HostMappingFailed {
+        hostname: String,
+        ip: String,
+        docker_container: Option<String>,
+        timestamp: u64,
+    },
+    ControlChannelClosed {
+        timestamp: u64,
+    },
+    ControlChannelAckFailed {
+        msg_id: String,
+        message_type: String,
+        timestamp: u64,
+    },
+    ServicesListUpdateFailed {
+        error_message: String,
+        num_services: u32,
+        timestamp: u64,
+    },
+    BackendTriggerSendFailed {
+        service_name: String,
+        port: u16,
+        error_message: String,
+        timestamp: u64,
+    },
+    FirewallRulesLoadFailed {
+        path: String,
+        error_message: String,
+        timestamp: u64,
+    },
+
+    // --- Client info events ---
+    VxlanSetupCompleted {
+        vxlan_id: u32,
+        ns_name: String,
+        timestamp: u64,
+    },
+    VlanSetupCompleted {
+        vlan_id: u16,
+        timestamp: u64,
+    },
+    ControlChannelEstablished {
+        timestamp: u64,
+    },
+    ServicesListUpdated {
+        num_services: u32,
+        timestamp: u64,
+    },
+
+    // --- Proxy error events ---
+    UpstreamLookupFailed {
+        service_name: String,
+        client_ip: String,
+        error_message: String,
+        timestamp: u64,
+    },
+    ProxyRequestMissingHost {
+        client_ip: String,
+        timestamp: u64,
+    },
+    ProxyRequestInvalidHost {
+        client_ip: String,
+        timestamp: u64,
+    },
+    UpstreamIpParseFailed {
+        raw_ip: String,
+        service_name: String,
+        timestamp: u64,
+    },
+    ProxyClientNotInet {
+        address_family: String,
+        timestamp: u64,
+    },
+
+    // --- Proxy info events ---
+    ProxyRequestRouted {
+        service_name: String,
+        client_ip: String,
+        upstream_ip: String,
+        latency_ms: u64,
+        timestamp: u64,
+    },
 }
 
 impl Event {
@@ -139,6 +273,76 @@ impl Event {
             Self::NetIdPoolExhausted { .. } => "net_id_pool_exhausted",
             Self::ProxyChainSetupFailed { .. } => "proxy_chain_setup_failed",
             Self::BackendTriggerSetupBailed { .. } => "backend_trigger_setup_bailed",
+            Self::VxlanSetupFailed { .. } => "vxlan_setup_failed",
+            Self::VlanSetupFailed { .. } => "vlan_setup_failed",
+            Self::VxlanTeardownFailed { .. } => "vxlan_teardown_failed",
+            Self::VlanTeardownFailed { .. } => "vlan_teardown_failed",
+            Self::DnatInstallFailed { .. } => "dnat_install_failed",
+            Self::DnatRemovalFailed { .. } => "dnat_removal_failed",
+            Self::HostMappingFailed { .. } => "host_mapping_failed",
+            Self::ControlChannelClosed { .. } => "control_channel_closed",
+            Self::ControlChannelAckFailed { .. } => "control_channel_ack_failed",
+            Self::ServicesListUpdateFailed { .. } => "services_list_update_failed",
+            Self::BackendTriggerSendFailed { .. } => "backend_trigger_send_failed",
+            Self::FirewallRulesLoadFailed { .. } => "firewall_rules_load_failed",
+            Self::VxlanSetupCompleted { .. } => "vxlan_setup_completed",
+            Self::VlanSetupCompleted { .. } => "vlan_setup_completed",
+            Self::ControlChannelEstablished { .. } => "control_channel_established",
+            Self::ServicesListUpdated { .. } => "services_list_updated",
+            Self::UpstreamLookupFailed { .. } => "upstream_lookup_failed",
+            Self::ProxyRequestMissingHost { .. } => "proxy_request_missing_host",
+            Self::ProxyRequestInvalidHost { .. } => "proxy_request_invalid_host",
+            Self::UpstreamIpParseFailed { .. } => "upstream_ip_parse_failed",
+            Self::ProxyClientNotInet { .. } => "proxy_client_not_inet",
+            Self::ProxyRequestRouted { .. } => "proxy_request_routed",
+        }
+    }
+
+    pub(crate) fn severity(&self) -> Severity {
+        match self {
+            Self::NodeConnected { .. }
+            | Self::ServiceRegistered { .. }
+            | Self::SetupStarted { .. }
+            | Self::SetupAck { .. }
+            | Self::SessionCreated { .. }
+            | Self::SessionTornDown { .. }
+            | Self::ConfigReloaded { .. }
+            | Self::StickySessionReused { .. }
+            | Self::VxlanSetupCompleted { .. }
+            | Self::VlanSetupCompleted { .. }
+            | Self::ControlChannelEstablished { .. }
+            | Self::ServicesListUpdated { .. }
+            | Self::ProxyRequestRouted { .. } => Severity::Info,
+
+            Self::NodeDisconnected { .. }
+            | Self::ServiceUnregistered { .. }
+            | Self::ConfigStackRemoved { .. }
+            | Self::AllReplicasRemoved { .. }
+            | Self::ServiceReachabilityToggled { .. }
+            | Self::ProxyClientTimedOut { .. }
+            | Self::MaxNetworksLimitEnforced { .. }
+            | Self::BackendTriggerSetupBailed { .. }
+            | Self::ControlChannelClosed { .. } => Severity::Warning,
+
+            Self::SetupTimeout { .. }
+            | Self::NetIdPoolExhausted { .. }
+            | Self::ProxyChainSetupFailed { .. }
+            | Self::VxlanSetupFailed { .. }
+            | Self::VlanSetupFailed { .. }
+            | Self::VxlanTeardownFailed { .. }
+            | Self::VlanTeardownFailed { .. }
+            | Self::DnatInstallFailed { .. }
+            | Self::DnatRemovalFailed { .. }
+            | Self::HostMappingFailed { .. }
+            | Self::ControlChannelAckFailed { .. }
+            | Self::ServicesListUpdateFailed { .. }
+            | Self::BackendTriggerSendFailed { .. }
+            | Self::FirewallRulesLoadFailed { .. }
+            | Self::UpstreamLookupFailed { .. }
+            | Self::ProxyRequestMissingHost { .. }
+            | Self::ProxyRequestInvalidHost { .. }
+            | Self::UpstreamIpParseFailed { .. }
+            | Self::ProxyClientNotInet { .. } => Severity::Error,
         }
     }
 
@@ -311,6 +515,111 @@ impl Event {
             timestamp: now_secs(),
         }
     }
+
+    pub(crate) fn vxlan_setup_failed(vxlan_id: u32, ns_name: String, error_code: i32) -> Self {
+        Self::VxlanSetupFailed { vxlan_id, ns_name, error_code, timestamp: now_secs() }
+    }
+
+    pub(crate) fn vlan_setup_failed(vlan_id: u16, local_veth: String, error_reason: String) -> Self {
+        Self::VlanSetupFailed { vlan_id, local_veth, error_reason, timestamp: now_secs() }
+    }
+
+    pub(crate) fn vxlan_teardown_failed(vxlan_id: u32, ns_name: String, error_code: i32) -> Self {
+        Self::VxlanTeardownFailed { vxlan_id, ns_name, error_code, timestamp: now_secs() }
+    }
+
+    pub(crate) fn vlan_teardown_failed(vlan_id: u16, error_reason: String) -> Self {
+        Self::VlanTeardownFailed { vlan_id, error_reason, timestamp: now_secs() }
+    }
+
+    pub(crate) fn dnat_install_failed(port: u16, overlay_ip: String) -> Self {
+        Self::DnatInstallFailed { port, overlay_ip, timestamp: now_secs() }
+    }
+
+    pub(crate) fn dnat_removal_failed(port: u16, overlay_ip: String) -> Self {
+        Self::DnatRemovalFailed { port, overlay_ip, timestamp: now_secs() }
+    }
+
+    pub(crate) fn host_mapping_failed(
+        hostname: String,
+        ip: String,
+        docker_container: Option<String>,
+    ) -> Self {
+        Self::HostMappingFailed { hostname, ip, docker_container, timestamp: now_secs() }
+    }
+
+    pub(crate) fn control_channel_closed() -> Self {
+        Self::ControlChannelClosed { timestamp: now_secs() }
+    }
+
+    pub(crate) fn control_channel_ack_failed(msg_id: String, message_type: String) -> Self {
+        Self::ControlChannelAckFailed { msg_id, message_type, timestamp: now_secs() }
+    }
+
+    pub(crate) fn services_list_update_failed(error_message: String, num_services: u32) -> Self {
+        Self::ServicesListUpdateFailed { error_message, num_services, timestamp: now_secs() }
+    }
+
+    pub(crate) fn backend_trigger_send_failed(
+        service_name: String,
+        port: u16,
+        error_message: String,
+    ) -> Self {
+        Self::BackendTriggerSendFailed { service_name, port, error_message, timestamp: now_secs() }
+    }
+
+    pub(crate) fn firewall_rules_load_failed(path: String, error_message: String) -> Self {
+        Self::FirewallRulesLoadFailed { path, error_message, timestamp: now_secs() }
+    }
+
+    pub(crate) fn vxlan_setup_completed(vxlan_id: u32, ns_name: String) -> Self {
+        Self::VxlanSetupCompleted { vxlan_id, ns_name, timestamp: now_secs() }
+    }
+
+    pub(crate) fn vlan_setup_completed(vlan_id: u16) -> Self {
+        Self::VlanSetupCompleted { vlan_id, timestamp: now_secs() }
+    }
+
+    pub(crate) fn control_channel_established() -> Self {
+        Self::ControlChannelEstablished { timestamp: now_secs() }
+    }
+
+    pub(crate) fn services_list_updated(num_services: u32) -> Self {
+        Self::ServicesListUpdated { num_services, timestamp: now_secs() }
+    }
+
+    pub(crate) fn upstream_lookup_failed(
+        service_name: String,
+        client_ip: String,
+        error_message: String,
+    ) -> Self {
+        Self::UpstreamLookupFailed { service_name, client_ip, error_message, timestamp: now_secs() }
+    }
+
+    pub(crate) fn proxy_request_missing_host(client_ip: String) -> Self {
+        Self::ProxyRequestMissingHost { client_ip, timestamp: now_secs() }
+    }
+
+    pub(crate) fn proxy_request_invalid_host(client_ip: String) -> Self {
+        Self::ProxyRequestInvalidHost { client_ip, timestamp: now_secs() }
+    }
+
+    pub(crate) fn upstream_ip_parse_failed(raw_ip: String, service_name: String) -> Self {
+        Self::UpstreamIpParseFailed { raw_ip, service_name, timestamp: now_secs() }
+    }
+
+    pub(crate) fn proxy_client_not_inet(address_family: String) -> Self {
+        Self::ProxyClientNotInet { address_family, timestamp: now_secs() }
+    }
+
+    pub(crate) fn proxy_request_routed(
+        service_name: String,
+        client_ip: String,
+        upstream_ip: String,
+        latency_ms: u64,
+    ) -> Self {
+        Self::ProxyRequestRouted { service_name, client_ip, upstream_ip, latency_ms, timestamp: now_secs() }
+    }
 }
 
 /// Shared event store: ring buffer + broadcast channel for SSE subscribers.
@@ -345,13 +654,19 @@ impl EventStore {
         let _ = self.tx.send(event);
     }
 
-    /// Return stored events, optionally filtered by kind and/or capped at limit.
+    /// Return stored events, optionally filtered by kind and/or severity, capped at limit.
     /// `limit` takes the most recent N events.
-    pub(crate) async fn snapshot(&self, limit: Option<usize>, kind: Option<&str>) -> Vec<Event> {
+    pub(crate) async fn snapshot(
+        &self,
+        limit: Option<usize>,
+        kind: Option<&str>,
+        severity: Option<Severity>,
+    ) -> Vec<Event> {
         let buf = self.buffer.lock().await;
         let filtered: Vec<Event> = buf
             .iter()
             .filter(|e| kind.is_none_or(|k| e.kind() == k))
+            .filter(|e| severity.is_none_or(|s| e.severity() == s))
             .cloned()
             .collect();
         match limit {

--- a/members/nullnet-server/src/events.rs
+++ b/members/nullnet-server/src/events.rs
@@ -1,0 +1,222 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use tokio::sync::{Mutex, broadcast};
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum Event {
+    NodeConnected {
+        ip: String,
+        timestamp: u64,
+    },
+    NodeDisconnected {
+        ip: String,
+        timestamp: u64,
+    },
+    ServiceRegistered {
+        name: String,
+        stack: String,
+        timestamp: u64,
+    },
+    ServiceUnregistered {
+        name: String,
+        stack: String,
+        timestamp: u64,
+    },
+    SetupStarted {
+        net_id: u32,
+        service: String,
+        client_ip: String,
+        timestamp: u64,
+    },
+    SetupAck {
+        net_id: u32,
+        service: String,
+        latency_ms: u64,
+        timestamp: u64,
+    },
+    SetupTimeout {
+        net_id: u32,
+        service: String,
+        timestamp: u64,
+    },
+    SessionCreated {
+        net_id: u32,
+        service: String,
+        client_ip: String,
+        timestamp: u64,
+    },
+    SessionTornDown {
+        net_id: u32,
+        service: String,
+        client_ip: String,
+        timestamp: u64,
+    },
+    ConfigReloaded {
+        stack: String,
+        timestamp: u64,
+    },
+}
+
+impl Event {
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::NodeConnected { .. } => "node_connected",
+            Self::NodeDisconnected { .. } => "node_disconnected",
+            Self::ServiceRegistered { .. } => "service_registered",
+            Self::ServiceUnregistered { .. } => "service_unregistered",
+            Self::SetupStarted { .. } => "setup_started",
+            Self::SetupAck { .. } => "setup_ack",
+            Self::SetupTimeout { .. } => "setup_timeout",
+            Self::SessionCreated { .. } => "session_created",
+            Self::SessionTornDown { .. } => "session_torn_down",
+            Self::ConfigReloaded { .. } => "config_reloaded",
+        }
+    }
+
+    pub(crate) fn node_connected(ip: String) -> Self {
+        Self::NodeConnected {
+            ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn node_disconnected(ip: String) -> Self {
+        Self::NodeDisconnected {
+            ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn service_registered(name: String, stack: String) -> Self {
+        Self::ServiceRegistered {
+            name,
+            stack,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn service_unregistered(name: String, stack: String) -> Self {
+        Self::ServiceUnregistered {
+            name,
+            stack,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn setup_started(net_id: u32, service: String, client_ip: String) -> Self {
+        Self::SetupStarted {
+            net_id,
+            service,
+            client_ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn setup_ack(net_id: u32, service: String, latency_ms: u64) -> Self {
+        Self::SetupAck {
+            net_id,
+            service,
+            latency_ms,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn setup_timeout(net_id: u32, service: String) -> Self {
+        Self::SetupTimeout {
+            net_id,
+            service,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn session_created(net_id: u32, service: String, client_ip: String) -> Self {
+        Self::SessionCreated {
+            net_id,
+            service,
+            client_ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn session_torn_down(net_id: u32, service: String, client_ip: String) -> Self {
+        Self::SessionTornDown {
+            net_id,
+            service,
+            client_ip,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn config_reloaded(stack: String) -> Self {
+        Self::ConfigReloaded {
+            stack,
+            timestamp: now_secs(),
+        }
+    }
+}
+
+/// Shared event store: ring buffer + broadcast channel for SSE subscribers.
+#[derive(Clone, Debug)]
+pub(crate) struct EventStore {
+    buffer: Arc<Mutex<VecDeque<Event>>>,
+    capacity: usize,
+    tx: broadcast::Sender<Event>,
+}
+
+impl EventStore {
+    pub(crate) fn new() -> Self {
+        let capacity = std::env::var("EVENT_BUFFER_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1000_usize);
+        let (tx, _) = broadcast::channel(512);
+        Self {
+            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
+            capacity,
+            tx,
+        }
+    }
+
+    pub(crate) async fn emit(&self, event: Event) {
+        let mut buf = self.buffer.lock().await;
+        if buf.len() >= self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(event.clone());
+        drop(buf);
+        let _ = self.tx.send(event);
+    }
+
+    /// Return stored events, optionally filtered by kind and/or capped at limit.
+    /// `limit` takes the most recent N events.
+    pub(crate) async fn snapshot(&self, limit: Option<usize>, kind: Option<&str>) -> Vec<Event> {
+        let buf = self.buffer.lock().await;
+        let filtered: Vec<Event> = buf
+            .iter()
+            .filter(|e| kind.is_none_or(|k| e.kind() == k))
+            .cloned()
+            .collect();
+        match limit {
+            Some(n) => {
+                let start = filtered.len().saturating_sub(n);
+                filtered[start..].to_vec()
+            }
+            None => filtered,
+        }
+    }
+
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<Event> {
+        self.tx.subscribe()
+    }
+}

--- a/members/nullnet-server/src/events.rs
+++ b/members/nullnet-server/src/events.rs
@@ -517,27 +517,58 @@ impl Event {
     }
 
     pub(crate) fn vxlan_setup_failed(vxlan_id: u32, ns_name: String, error_code: i32) -> Self {
-        Self::VxlanSetupFailed { vxlan_id, ns_name, error_code, timestamp: now_secs() }
+        Self::VxlanSetupFailed {
+            vxlan_id,
+            ns_name,
+            error_code,
+            timestamp: now_secs(),
+        }
     }
 
-    pub(crate) fn vlan_setup_failed(vlan_id: u16, local_veth: String, error_reason: String) -> Self {
-        Self::VlanSetupFailed { vlan_id, local_veth, error_reason, timestamp: now_secs() }
+    pub(crate) fn vlan_setup_failed(
+        vlan_id: u16,
+        local_veth: String,
+        error_reason: String,
+    ) -> Self {
+        Self::VlanSetupFailed {
+            vlan_id,
+            local_veth,
+            error_reason,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn vxlan_teardown_failed(vxlan_id: u32, ns_name: String, error_code: i32) -> Self {
-        Self::VxlanTeardownFailed { vxlan_id, ns_name, error_code, timestamp: now_secs() }
+        Self::VxlanTeardownFailed {
+            vxlan_id,
+            ns_name,
+            error_code,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn vlan_teardown_failed(vlan_id: u16, error_reason: String) -> Self {
-        Self::VlanTeardownFailed { vlan_id, error_reason, timestamp: now_secs() }
+        Self::VlanTeardownFailed {
+            vlan_id,
+            error_reason,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn dnat_install_failed(port: u16, overlay_ip: String) -> Self {
-        Self::DnatInstallFailed { port, overlay_ip, timestamp: now_secs() }
+        Self::DnatInstallFailed {
+            port,
+            overlay_ip,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn dnat_removal_failed(port: u16, overlay_ip: String) -> Self {
-        Self::DnatRemovalFailed { port, overlay_ip, timestamp: now_secs() }
+        Self::DnatRemovalFailed {
+            port,
+            overlay_ip,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn host_mapping_failed(
@@ -545,19 +576,34 @@ impl Event {
         ip: String,
         docker_container: Option<String>,
     ) -> Self {
-        Self::HostMappingFailed { hostname, ip, docker_container, timestamp: now_secs() }
+        Self::HostMappingFailed {
+            hostname,
+            ip,
+            docker_container,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn control_channel_closed() -> Self {
-        Self::ControlChannelClosed { timestamp: now_secs() }
+        Self::ControlChannelClosed {
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn control_channel_ack_failed(msg_id: String, message_type: String) -> Self {
-        Self::ControlChannelAckFailed { msg_id, message_type, timestamp: now_secs() }
+        Self::ControlChannelAckFailed {
+            msg_id,
+            message_type,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn services_list_update_failed(error_message: String, num_services: u32) -> Self {
-        Self::ServicesListUpdateFailed { error_message, num_services, timestamp: now_secs() }
+        Self::ServicesListUpdateFailed {
+            error_message,
+            num_services,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn backend_trigger_send_failed(
@@ -565,27 +611,48 @@ impl Event {
         port: u16,
         error_message: String,
     ) -> Self {
-        Self::BackendTriggerSendFailed { service_name, port, error_message, timestamp: now_secs() }
+        Self::BackendTriggerSendFailed {
+            service_name,
+            port,
+            error_message,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn firewall_rules_load_failed(path: String, error_message: String) -> Self {
-        Self::FirewallRulesLoadFailed { path, error_message, timestamp: now_secs() }
+        Self::FirewallRulesLoadFailed {
+            path,
+            error_message,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn vxlan_setup_completed(vxlan_id: u32, ns_name: String) -> Self {
-        Self::VxlanSetupCompleted { vxlan_id, ns_name, timestamp: now_secs() }
+        Self::VxlanSetupCompleted {
+            vxlan_id,
+            ns_name,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn vlan_setup_completed(vlan_id: u16) -> Self {
-        Self::VlanSetupCompleted { vlan_id, timestamp: now_secs() }
+        Self::VlanSetupCompleted {
+            vlan_id,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn control_channel_established() -> Self {
-        Self::ControlChannelEstablished { timestamp: now_secs() }
+        Self::ControlChannelEstablished {
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn services_list_updated(num_services: u32) -> Self {
-        Self::ServicesListUpdated { num_services, timestamp: now_secs() }
+        Self::ServicesListUpdated {
+            num_services,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn upstream_lookup_failed(
@@ -593,23 +660,41 @@ impl Event {
         client_ip: String,
         error_message: String,
     ) -> Self {
-        Self::UpstreamLookupFailed { service_name, client_ip, error_message, timestamp: now_secs() }
+        Self::UpstreamLookupFailed {
+            service_name,
+            client_ip,
+            error_message,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn proxy_request_missing_host(client_ip: String) -> Self {
-        Self::ProxyRequestMissingHost { client_ip, timestamp: now_secs() }
+        Self::ProxyRequestMissingHost {
+            client_ip,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn proxy_request_invalid_host(client_ip: String) -> Self {
-        Self::ProxyRequestInvalidHost { client_ip, timestamp: now_secs() }
+        Self::ProxyRequestInvalidHost {
+            client_ip,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn upstream_ip_parse_failed(raw_ip: String, service_name: String) -> Self {
-        Self::UpstreamIpParseFailed { raw_ip, service_name, timestamp: now_secs() }
+        Self::UpstreamIpParseFailed {
+            raw_ip,
+            service_name,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn proxy_client_not_inet(address_family: String) -> Self {
-        Self::ProxyClientNotInet { address_family, timestamp: now_secs() }
+        Self::ProxyClientNotInet {
+            address_family,
+            timestamp: now_secs(),
+        }
     }
 
     pub(crate) fn proxy_request_routed(
@@ -618,7 +703,13 @@ impl Event {
         upstream_ip: String,
         latency_ms: u64,
     ) -> Self {
-        Self::ProxyRequestRouted { service_name, client_ip, upstream_ip, latency_ms, timestamp: now_secs() }
+        Self::ProxyRequestRouted {
+            service_name,
+            client_ip,
+            upstream_ip,
+            latency_ms,
+            timestamp: now_secs(),
+        }
     }
 }
 

--- a/members/nullnet-server/src/http_server/events.rs
+++ b/members/nullnet-server/src/http_server/events.rs
@@ -1,0 +1,21 @@
+use crate::http_server::AppState;
+use axum::Json;
+use axum::extract::{Query, State};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub(crate) struct EventsQuery {
+    limit: Option<usize>,
+    kind: Option<String>,
+}
+
+pub(crate) async fn events_handler(
+    State(state): State<AppState>,
+    Query(params): Query<EventsQuery>,
+) -> Json<serde_json::Value> {
+    let events = state
+        .events
+        .snapshot(params.limit, params.kind.as_deref())
+        .await;
+    Json(serde_json::to_value(events).unwrap_or(serde_json::Value::Array(vec![])))
+}

--- a/members/nullnet-server/src/http_server/events.rs
+++ b/members/nullnet-server/src/http_server/events.rs
@@ -21,7 +21,10 @@ pub(crate) async fn events_handler(
         .await;
     let envelopes: Vec<EventEnvelope<'_>> = events
         .iter()
-        .map(|e| EventEnvelope { severity: e.severity(), event: e })
+        .map(|e| EventEnvelope {
+            severity: e.severity(),
+            event: e,
+        })
         .collect();
     Json(serde_json::to_value(envelopes).unwrap_or(serde_json::Value::Array(vec![])))
 }

--- a/members/nullnet-server/src/http_server/events.rs
+++ b/members/nullnet-server/src/http_server/events.rs
@@ -1,3 +1,4 @@
+use crate::events::{EventEnvelope, Severity};
 use crate::http_server::AppState;
 use axum::Json;
 use axum::extract::{Query, State};
@@ -7,6 +8,7 @@ use serde::Deserialize;
 pub(crate) struct EventsQuery {
     limit: Option<usize>,
     kind: Option<String>,
+    severity: Option<Severity>,
 }
 
 pub(crate) async fn events_handler(
@@ -15,7 +17,11 @@ pub(crate) async fn events_handler(
 ) -> Json<serde_json::Value> {
     let events = state
         .events
-        .snapshot(params.limit, params.kind.as_deref())
+        .snapshot(params.limit, params.kind.as_deref(), params.severity)
         .await;
-    Json(serde_json::to_value(events).unwrap_or(serde_json::Value::Array(vec![])))
+    let envelopes: Vec<EventEnvelope<'_>> = events
+        .iter()
+        .map(|e| EventEnvelope { severity: e.severity(), event: e })
+        .collect();
+    Json(serde_json::to_value(envelopes).unwrap_or(serde_json::Value::Array(vec![])))
 }

--- a/members/nullnet-server/src/http_server/events_stream.rs
+++ b/members/nullnet-server/src/http_server/events_stream.rs
@@ -1,0 +1,33 @@
+use crate::http_server::AppState;
+use axum::extract::State;
+use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
+use futures::stream::{self, StreamExt};
+use std::convert::Infallible;
+use tokio_stream::wrappers::BroadcastStream;
+
+pub(crate) async fn events_stream_handler(
+    State(state): State<AppState>,
+) -> Sse<impl futures::Stream<Item = Result<SseEvent, Infallible>>> {
+    let backfill = state.events.snapshot(None, None).await;
+    let rx = state.events.subscribe();
+
+    let backfill_stream = stream::iter(backfill.into_iter().map(|e| {
+        Ok::<_, Infallible>(
+            SseEvent::default()
+                .event(e.kind())
+                .data(serde_json::to_string(&e).unwrap_or_default()),
+        )
+    }));
+
+    let live_stream = BroadcastStream::new(rx).filter_map(|result| async move {
+        result.ok().map(|e| {
+            Ok::<_, Infallible>(
+                SseEvent::default()
+                    .event(e.kind())
+                    .data(serde_json::to_string(&e).unwrap_or_default()),
+            )
+        })
+    });
+
+    Sse::new(backfill_stream.chain(live_stream)).keep_alive(KeepAlive::default())
+}

--- a/members/nullnet-server/src/http_server/events_stream.rs
+++ b/members/nullnet-server/src/http_server/events_stream.rs
@@ -1,3 +1,4 @@
+use crate::events::EventEnvelope;
 use crate::http_server::AppState;
 use axum::extract::State;
 use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
@@ -8,17 +9,19 @@ use tokio_stream::wrappers::BroadcastStream;
 pub(crate) async fn events_stream_handler(
     State(state): State<AppState>,
 ) -> Sse<impl futures::Stream<Item = Result<SseEvent, Infallible>>> {
-    let backfill = state.events.snapshot(None, None).await;
+    let backfill = state.events.snapshot(None, None, None).await;
     let rx = state.events.subscribe();
 
     let backfill_stream = stream::iter(backfill.into_iter().map(|e| {
-        Ok::<_, Infallible>(SseEvent::default().data(serde_json::to_string(&e).unwrap_or_default()))
+        let env = EventEnvelope { severity: e.severity(), event: &e };
+        Ok::<_, Infallible>(SseEvent::default().data(serde_json::to_string(&env).unwrap_or_default()))
     }));
 
     let live_stream = BroadcastStream::new(rx).filter_map(|result| async move {
         result.ok().map(|e| {
+            let env = EventEnvelope { severity: e.severity(), event: &e };
             Ok::<_, Infallible>(
-                SseEvent::default().data(serde_json::to_string(&e).unwrap_or_default()),
+                SseEvent::default().data(serde_json::to_string(&env).unwrap_or_default()),
             )
         })
     });

--- a/members/nullnet-server/src/http_server/events_stream.rs
+++ b/members/nullnet-server/src/http_server/events_stream.rs
@@ -13,13 +13,21 @@ pub(crate) async fn events_stream_handler(
     let rx = state.events.subscribe();
 
     let backfill_stream = stream::iter(backfill.into_iter().map(|e| {
-        let env = EventEnvelope { severity: e.severity(), event: &e };
-        Ok::<_, Infallible>(SseEvent::default().data(serde_json::to_string(&env).unwrap_or_default()))
+        let env = EventEnvelope {
+            severity: e.severity(),
+            event: &e,
+        };
+        Ok::<_, Infallible>(
+            SseEvent::default().data(serde_json::to_string(&env).unwrap_or_default()),
+        )
     }));
 
     let live_stream = BroadcastStream::new(rx).filter_map(|result| async move {
         result.ok().map(|e| {
-            let env = EventEnvelope { severity: e.severity(), event: &e };
+            let env = EventEnvelope {
+                severity: e.severity(),
+                event: &e,
+            };
             Ok::<_, Infallible>(
                 SseEvent::default().data(serde_json::to_string(&env).unwrap_or_default()),
             )

--- a/members/nullnet-server/src/http_server/events_stream.rs
+++ b/members/nullnet-server/src/http_server/events_stream.rs
@@ -13,18 +13,14 @@ pub(crate) async fn events_stream_handler(
 
     let backfill_stream = stream::iter(backfill.into_iter().map(|e| {
         Ok::<_, Infallible>(
-            SseEvent::default()
-                .event(e.kind())
-                .data(serde_json::to_string(&e).unwrap_or_default()),
+            SseEvent::default().data(serde_json::to_string(&e).unwrap_or_default()),
         )
     }));
 
     let live_stream = BroadcastStream::new(rx).filter_map(|result| async move {
         result.ok().map(|e| {
             Ok::<_, Infallible>(
-                SseEvent::default()
-                    .event(e.kind())
-                    .data(serde_json::to_string(&e).unwrap_or_default()),
+                SseEvent::default().data(serde_json::to_string(&e).unwrap_or_default()),
             )
         })
     });

--- a/members/nullnet-server/src/http_server/events_stream.rs
+++ b/members/nullnet-server/src/http_server/events_stream.rs
@@ -12,9 +12,7 @@ pub(crate) async fn events_stream_handler(
     let rx = state.events.subscribe();
 
     let backfill_stream = stream::iter(backfill.into_iter().map(|e| {
-        Ok::<_, Infallible>(
-            SseEvent::default().data(serde_json::to_string(&e).unwrap_or_default()),
-        )
+        Ok::<_, Infallible>(SseEvent::default().data(serde_json::to_string(&e).unwrap_or_default()))
     }));
 
     let live_stream = BroadcastStream::new(rx).filter_map(|result| async move {

--- a/members/nullnet-server/src/http_server/mod.rs
+++ b/members/nullnet-server/src/http_server/mod.rs
@@ -1,3 +1,4 @@
+use crate::events::EventStore;
 use crate::orchestrator::Orchestrator;
 use crate::services::input::StackMap;
 use axum::Router;
@@ -7,6 +8,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 mod config;
+mod events;
+mod events_stream;
 mod graph;
 mod health;
 mod nodes;
@@ -21,6 +24,7 @@ const HTTP_PORT: u16 = 8080;
 pub(crate) struct AppState {
     pub(crate) services: Arc<RwLock<StackMap>>,
     pub(crate) orchestrator: Orchestrator,
+    pub(crate) events: EventStore,
 }
 
 pub async fn serve(state: AppState) {
@@ -33,6 +37,11 @@ pub async fn serve(state: AppState) {
         .route("/api/graph/{stack}", get(graph::graph_handler))
         .route("/api/sessions", get(sessions::list_handler))
         .route("/api/sessions/{id}", delete(sessions::teardown_handler))
+        .route("/api/events", get(events::events_handler))
+        .route(
+            "/api/events/stream",
+            get(events_stream::events_stream_handler),
+        )
         .fallback(get(static_files::static_handler))
         .with_state(state);
 

--- a/members/nullnet-server/src/http_server/sessions.rs
+++ b/members/nullnet-server/src/http_server/sessions.rs
@@ -95,7 +95,7 @@ pub(super) async fn teardown_handler(
         return StatusCode::NOT_FOUND.into_response();
     };
     let changes = vec![ServiceChange::ForceSessionTeardown { name, client }];
-    apply_changes(changes, stack_map, None, &state.orchestrator).await;
+    apply_changes(changes, stack_map, None, &state.orchestrator, &stack).await;
 
     StatusCode::NO_CONTENT.into_response()
 }

--- a/members/nullnet-server/src/main.rs
+++ b/members/nullnet-server/src/main.rs
@@ -1,4 +1,5 @@
 mod env;
+mod events;
 mod graphviz;
 mod http_server;
 mod net;
@@ -37,6 +38,7 @@ async fn main() -> Result<(), Error> {
     let nullnet = init_nullnet().await?;
     let app_state = http_server::AppState {
         services: nullnet.services().clone(),
+        events: nullnet.orchestrator().events.clone(),
         orchestrator: nullnet.orchestrator().clone(),
     };
 

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -1,4 +1,5 @@
 use crate::env::NET_TYPE;
+use crate::events::Event;
 use crate::graphviz::generate_graphviz;
 use crate::orchestrator::Orchestrator;
 use crate::services::changes::{
@@ -570,7 +571,7 @@ impl NullnetGrpcImpl {
                 continue;
             };
             let changes = detect_services_list_changes(stack_map, sender_ip, stack_list);
-            apply_changes(changes, stack_map, None, &self.orchestrator).await;
+            apply_changes(changes, stack_map, None, &self.orchestrator, stack).await;
         }
 
         // Add/update replicas for services in the matching stacks.
@@ -582,6 +583,10 @@ impl NullnetGrpcImpl {
                 stack_map.entry(name.clone()).and_modify(|si| {
                     si.add_replica(sender_ip, *port, docker_container.clone());
                 });
+                self.orchestrator
+                    .events
+                    .emit(Event::service_registered(name.clone(), stack.clone()))
+                    .await;
             }
         }
 
@@ -652,6 +657,17 @@ impl NullnetGrpcImpl {
                     return EdgeOutcome::Failed;
                 };
 
+                if client.is_proxy().is_some() {
+                    orchestrator
+                        .events
+                        .emit(Event::setup_started(
+                            net_id,
+                            server.name().to_string(),
+                            client_ethernet.to_string(),
+                        ))
+                        .await;
+                }
+
                 let orch = orchestrator.clone();
                 let cd = client_docker.clone();
                 let sd = server_docker.clone();
@@ -678,6 +694,12 @@ impl NullnetGrpcImpl {
                 let (server_ok, client_ok) = tokio::join!(server_res, client_res);
 
                 if server_ok.is_none() || client_ok.is_none() {
+                    if client.is_proxy().is_some() {
+                        orchestrator
+                            .events
+                            .emit(Event::setup_timeout(net_id, server.name().to_string()))
+                            .await;
+                    }
                     // rollback
                     orchestrator
                         .send_net_teardown(
@@ -703,6 +725,17 @@ impl NullnetGrpcImpl {
 
                 println!("{server_ethernet} acknowledged");
                 println!("{client_ethernet} acknowledged");
+
+                if client.is_proxy().is_some() {
+                    orchestrator
+                        .events
+                        .emit(Event::setup_ack(
+                            net_id,
+                            server.name().to_string(),
+                            init_time.elapsed().as_millis() as u64,
+                        ))
+                        .await;
+                }
 
                 // register the link between the two services
                 let mut guard = services.write().await;
@@ -747,6 +780,14 @@ impl NullnetGrpcImpl {
                 }
 
                 let proxy_upstream = if client.is_proxy().is_some() {
+                    orchestrator
+                        .events
+                        .emit(Event::session_created(
+                            net_id,
+                            server.name().to_string(),
+                            client_ethernet.to_string(),
+                        ))
+                        .await;
                     Some(net_ip_server)
                 } else {
                     None

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -13,8 +13,7 @@ use crate::timeout::check_timeouts;
 use nullnet_grpc_lib::nullnet_grpc::nullnet_grpc_server::NullnetGrpc;
 use nullnet_grpc_lib::nullnet_grpc::{
     AgentEvent, BackendTriggerRequest, Empty, MsgId, NetMessage, NetType, ProxyRequest,
-    ServiceTrigger, Services, ServicesListResponse, Upstream,
-    agent_event::Event as AgentEventKind,
+    ServiceTrigger, Services, ServicesListResponse, Upstream, agent_event::Event as AgentEventKind,
 };
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::collections::{HashMap, HashSet};
@@ -977,58 +976,70 @@ impl NullnetGrpc for NullnetGrpcImpl {
             .map_err(|err| Status::internal(err.to_str()))
     }
 
-    async fn report_event(
-        &self,
-        req: Request<AgentEvent>,
-    ) -> Result<Response<Empty>, Status> {
+    async fn report_event(&self, req: Request<AgentEvent>) -> Result<Response<Empty>, Status> {
         let Some(kind) = req.into_inner().event else {
             return Ok(Response::new(Empty {}));
         };
         let event = match kind {
-            AgentEventKind::VxlanSetupFailed(e) =>
-                Event::vxlan_setup_failed(e.vxlan_id, e.ns_name, e.error_code),
-            AgentEventKind::VlanSetupFailed(e) =>
-                Event::vlan_setup_failed(e.vlan_id as u16, e.local_veth, e.error_reason),
-            AgentEventKind::VxlanTeardownFailed(e) =>
-                Event::vxlan_teardown_failed(e.vxlan_id, e.ns_name, e.error_code),
-            AgentEventKind::VlanTeardownFailed(e) =>
-                Event::vlan_teardown_failed(e.vlan_id as u16, e.error_reason),
-            AgentEventKind::DnatInstallFailed(e) =>
-                Event::dnat_install_failed(e.port as u16, e.overlay_ip),
-            AgentEventKind::DnatRemovalFailed(e) =>
-                Event::dnat_removal_failed(e.port as u16, e.overlay_ip),
-            AgentEventKind::HostMappingFailed(e) =>
-                Event::host_mapping_failed(e.hostname, e.ip, e.docker_container),
-            AgentEventKind::ControlChannelClosed(_) =>
-                Event::control_channel_closed(),
-            AgentEventKind::ControlChannelAckFailed(e) =>
-                Event::control_channel_ack_failed(e.msg_id, e.message_type),
-            AgentEventKind::ServicesListUpdateFailed(e) =>
-                Event::services_list_update_failed(e.error_message, e.num_services),
-            AgentEventKind::BackendTriggerSendFailed(e) =>
-                Event::backend_trigger_send_failed(e.service_name, e.port as u16, e.error_message),
-            AgentEventKind::FirewallRulesLoadFailed(e) =>
-                Event::firewall_rules_load_failed(e.path, e.error_message),
-            AgentEventKind::VxlanSetupCompleted(e) =>
-                Event::vxlan_setup_completed(e.vxlan_id, e.ns_name),
-            AgentEventKind::VlanSetupCompleted(e) =>
-                Event::vlan_setup_completed(e.vlan_id as u16),
-            AgentEventKind::ControlChannelEstablished(_) =>
-                Event::control_channel_established(),
-            AgentEventKind::ServicesListUpdated(e) =>
-                Event::services_list_updated(e.num_services),
-            AgentEventKind::UpstreamLookupFailed(e) =>
-                Event::upstream_lookup_failed(e.service_name, e.client_ip, e.error_message),
-            AgentEventKind::ProxyRequestMissingHost(e) =>
-                Event::proxy_request_missing_host(e.client_ip),
-            AgentEventKind::ProxyRequestInvalidHost(e) =>
-                Event::proxy_request_invalid_host(e.client_ip),
-            AgentEventKind::UpstreamIpParseFailed(e) =>
-                Event::upstream_ip_parse_failed(e.raw_ip, e.service_name),
-            AgentEventKind::ProxyClientNotInet(e) =>
-                Event::proxy_client_not_inet(e.address_family),
-            AgentEventKind::ProxyRequestRouted(e) =>
-                Event::proxy_request_routed(e.service_name, e.client_ip, e.upstream_ip, e.latency_ms),
+            AgentEventKind::VxlanSetupFailed(e) => {
+                Event::vxlan_setup_failed(e.vxlan_id, e.ns_name, e.error_code)
+            }
+            AgentEventKind::VlanSetupFailed(e) => {
+                Event::vlan_setup_failed(e.vlan_id as u16, e.local_veth, e.error_reason)
+            }
+            AgentEventKind::VxlanTeardownFailed(e) => {
+                Event::vxlan_teardown_failed(e.vxlan_id, e.ns_name, e.error_code)
+            }
+            AgentEventKind::VlanTeardownFailed(e) => {
+                Event::vlan_teardown_failed(e.vlan_id as u16, e.error_reason)
+            }
+            AgentEventKind::DnatInstallFailed(e) => {
+                Event::dnat_install_failed(e.port as u16, e.overlay_ip)
+            }
+            AgentEventKind::DnatRemovalFailed(e) => {
+                Event::dnat_removal_failed(e.port as u16, e.overlay_ip)
+            }
+            AgentEventKind::HostMappingFailed(e) => {
+                Event::host_mapping_failed(e.hostname, e.ip, e.docker_container)
+            }
+            AgentEventKind::ControlChannelClosed(_) => Event::control_channel_closed(),
+            AgentEventKind::ControlChannelAckFailed(e) => {
+                Event::control_channel_ack_failed(e.msg_id, e.message_type)
+            }
+            AgentEventKind::ServicesListUpdateFailed(e) => {
+                Event::services_list_update_failed(e.error_message, e.num_services)
+            }
+            AgentEventKind::BackendTriggerSendFailed(e) => {
+                Event::backend_trigger_send_failed(e.service_name, e.port as u16, e.error_message)
+            }
+            AgentEventKind::FirewallRulesLoadFailed(e) => {
+                Event::firewall_rules_load_failed(e.path, e.error_message)
+            }
+            AgentEventKind::VxlanSetupCompleted(e) => {
+                Event::vxlan_setup_completed(e.vxlan_id, e.ns_name)
+            }
+            AgentEventKind::VlanSetupCompleted(e) => Event::vlan_setup_completed(e.vlan_id as u16),
+            AgentEventKind::ControlChannelEstablished(_) => Event::control_channel_established(),
+            AgentEventKind::ServicesListUpdated(e) => Event::services_list_updated(e.num_services),
+            AgentEventKind::UpstreamLookupFailed(e) => {
+                Event::upstream_lookup_failed(e.service_name, e.client_ip, e.error_message)
+            }
+            AgentEventKind::ProxyRequestMissingHost(e) => {
+                Event::proxy_request_missing_host(e.client_ip)
+            }
+            AgentEventKind::ProxyRequestInvalidHost(e) => {
+                Event::proxy_request_invalid_host(e.client_ip)
+            }
+            AgentEventKind::UpstreamIpParseFailed(e) => {
+                Event::upstream_ip_parse_failed(e.raw_ip, e.service_name)
+            }
+            AgentEventKind::ProxyClientNotInet(e) => Event::proxy_client_not_inet(e.address_family),
+            AgentEventKind::ProxyRequestRouted(e) => Event::proxy_request_routed(
+                e.service_name,
+                e.client_ip,
+                e.upstream_ip,
+                e.latency_ms,
+            ),
         };
         self.orchestrator.events.emit(event).await;
         Ok(Response::new(Empty {}))

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -12,8 +12,9 @@ use crate::services::service_info::ServiceInfo;
 use crate::timeout::check_timeouts;
 use nullnet_grpc_lib::nullnet_grpc::nullnet_grpc_server::NullnetGrpc;
 use nullnet_grpc_lib::nullnet_grpc::{
-    BackendTriggerRequest, Empty, MsgId, NetMessage, NetType, ProxyRequest, ServiceTrigger,
-    Services, ServicesListResponse, Upstream,
+    AgentEvent, BackendTriggerRequest, Empty, MsgId, NetMessage, NetType, ProxyRequest,
+    ServiceTrigger, Services, ServicesListResponse, Upstream,
+    agent_event::Event as AgentEventKind,
 };
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::collections::{HashMap, HashSet};
@@ -974,5 +975,62 @@ impl NullnetGrpc for NullnetGrpcImpl {
         self.backend_trigger_impl(req)
             .await
             .map_err(|err| Status::internal(err.to_str()))
+    }
+
+    async fn report_event(
+        &self,
+        req: Request<AgentEvent>,
+    ) -> Result<Response<Empty>, Status> {
+        let Some(kind) = req.into_inner().event else {
+            return Ok(Response::new(Empty {}));
+        };
+        let event = match kind {
+            AgentEventKind::VxlanSetupFailed(e) =>
+                Event::vxlan_setup_failed(e.vxlan_id, e.ns_name, e.error_code),
+            AgentEventKind::VlanSetupFailed(e) =>
+                Event::vlan_setup_failed(e.vlan_id as u16, e.local_veth, e.error_reason),
+            AgentEventKind::VxlanTeardownFailed(e) =>
+                Event::vxlan_teardown_failed(e.vxlan_id, e.ns_name, e.error_code),
+            AgentEventKind::VlanTeardownFailed(e) =>
+                Event::vlan_teardown_failed(e.vlan_id as u16, e.error_reason),
+            AgentEventKind::DnatInstallFailed(e) =>
+                Event::dnat_install_failed(e.port as u16, e.overlay_ip),
+            AgentEventKind::DnatRemovalFailed(e) =>
+                Event::dnat_removal_failed(e.port as u16, e.overlay_ip),
+            AgentEventKind::HostMappingFailed(e) =>
+                Event::host_mapping_failed(e.hostname, e.ip, e.docker_container),
+            AgentEventKind::ControlChannelClosed(_) =>
+                Event::control_channel_closed(),
+            AgentEventKind::ControlChannelAckFailed(e) =>
+                Event::control_channel_ack_failed(e.msg_id, e.message_type),
+            AgentEventKind::ServicesListUpdateFailed(e) =>
+                Event::services_list_update_failed(e.error_message, e.num_services),
+            AgentEventKind::BackendTriggerSendFailed(e) =>
+                Event::backend_trigger_send_failed(e.service_name, e.port as u16, e.error_message),
+            AgentEventKind::FirewallRulesLoadFailed(e) =>
+                Event::firewall_rules_load_failed(e.path, e.error_message),
+            AgentEventKind::VxlanSetupCompleted(e) =>
+                Event::vxlan_setup_completed(e.vxlan_id, e.ns_name),
+            AgentEventKind::VlanSetupCompleted(e) =>
+                Event::vlan_setup_completed(e.vlan_id as u16),
+            AgentEventKind::ControlChannelEstablished(_) =>
+                Event::control_channel_established(),
+            AgentEventKind::ServicesListUpdated(e) =>
+                Event::services_list_updated(e.num_services),
+            AgentEventKind::UpstreamLookupFailed(e) =>
+                Event::upstream_lookup_failed(e.service_name, e.client_ip, e.error_message),
+            AgentEventKind::ProxyRequestMissingHost(e) =>
+                Event::proxy_request_missing_host(e.client_ip),
+            AgentEventKind::ProxyRequestInvalidHost(e) =>
+                Event::proxy_request_invalid_host(e.client_ip),
+            AgentEventKind::UpstreamIpParseFailed(e) =>
+                Event::upstream_ip_parse_failed(e.raw_ip, e.service_name),
+            AgentEventKind::ProxyClientNotInet(e) =>
+                Event::proxy_client_not_inet(e.address_family),
+            AgentEventKind::ProxyRequestRouted(e) =>
+                Event::proxy_request_routed(e.service_name, e.client_ip, e.upstream_ip, e.latency_ms),
+        };
+        self.orchestrator.events.emit(event).await;
+        Ok(Response::new(Empty {}))
     }
 }

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -145,6 +145,15 @@ impl NullnetGrpcImpl {
         if let Some(upstream) = registered.is_client_setup(&proxy_client) {
             println!("'{client_ip}' ---> '{service_name}' is already set up");
 
+            self.orchestrator
+                .events
+                .emit(Event::sticky_session_reused(
+                    service_name.to_string(),
+                    client_ip.to_string(),
+                    proxy_ip.to_string(),
+                ))
+                .await;
+
             // update the latest timestamp for this client since it's being used again
             let mut services_mut = self.services.write().await;
             if let Some(stack_map) = services_mut.get_mut(&stack)
@@ -167,6 +176,15 @@ impl NullnetGrpcImpl {
                 "Max networks ({max}) reached for '{service_name}', \
                  reusing network on proxy {proxy_ip}"
             );
+            self.orchestrator
+                .events
+                .emit(Event::max_networks_limit_enforced(
+                    service_name.to_string(),
+                    proxy_ip.to_string(),
+                    net_id,
+                    max,
+                ))
+                .await;
             let mut services_mut = self.services.write().await;
             if let Some(stack_map) = services_mut.get_mut(&stack) {
                 if let Some(ServiceInfo::Registered(reg)) = stack_map.get_mut(service_name) {
@@ -196,10 +214,22 @@ impl NullnetGrpcImpl {
             return Ok(upstream);
         }
 
-        let response = self
+        match self
             .new_proxy_chain(&stack, service_name, proxy_ip, client_ip)
-            .await?;
-        Ok(response.into_inner())
+            .await
+        {
+            Ok(response) => Ok(response.into_inner()),
+            Err(e) => {
+                self.orchestrator
+                    .events
+                    .emit(Event::proxy_chain_setup_failed(
+                        service_name.to_string(),
+                        client_ip.to_string(),
+                    ))
+                    .await;
+                Err(e)
+            }
+        }
     }
 
     async fn services_list_impl(
@@ -524,6 +554,13 @@ impl NullnetGrpcImpl {
             println!(
                 "[trigger] build_backend_dep_chain returned None for '{initiator_name}' port {port}"
             );
+            self.orchestrator
+                .events
+                .emit(Event::backend_trigger_setup_bailed(
+                    initiator_name.to_string(),
+                    port,
+                ))
+                .await;
             return Ok(());
         };
         println!(
@@ -648,6 +685,13 @@ impl NullnetGrpcImpl {
 
                 let Some(net_id) = orchestrator.allocate_net_id().await else {
                     eprintln!("NET ID pool exhausted");
+                    orchestrator
+                        .events
+                        .emit(Event::net_id_pool_exhausted(
+                            server.name().to_string(),
+                            client_ethernet.to_string(),
+                        ))
+                        .await;
                     // remove placeholder
                     if let Some(stack_map) = services.write().await.get_mut(&stack)
                         && let Some(ServiceInfo::Registered(reg)) = stack_map.get_mut(server.name())

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -617,13 +617,19 @@ impl NullnetGrpcImpl {
                 continue;
             };
             for (name, port, docker_container) in list {
+                let is_new = stack_map
+                    .get(name)
+                    .map(|si| !si.has_replica(sender_ip, docker_container.as_deref()))
+                    .unwrap_or(false);
                 stack_map.entry(name.clone()).and_modify(|si| {
                     si.add_replica(sender_ip, *port, docker_container.clone());
                 });
-                self.orchestrator
-                    .events
-                    .emit(Event::service_registered(name.clone(), stack.clone()))
-                    .await;
+                if is_new {
+                    self.orchestrator
+                        .events
+                        .emit(Event::service_registered(name.clone(), stack.clone()))
+                        .await;
+                }
             }
         }
 

--- a/members/nullnet-server/src/orchestrator.rs
+++ b/members/nullnet-server/src/orchestrator.rs
@@ -1,4 +1,5 @@
 use crate::env::NET_TYPE;
+use crate::events::{Event, EventStore};
 use crate::net::NetExt;
 use crate::net_id_pool::NetIdPool;
 use crate::services::changes::{apply_changes, detect_node_disconnect_changes};
@@ -20,6 +21,7 @@ pub struct Orchestrator {
     clients: Arc<RwLock<HashMap<IpAddr, OutboundStream>>>,
     pending: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
     net_id_pool: Arc<Mutex<NetIdPool>>,
+    pub(crate) events: EventStore,
 }
 
 impl Orchestrator {
@@ -28,6 +30,7 @@ impl Orchestrator {
             clients: Arc::new(RwLock::new(HashMap::new())),
             pending: Arc::new(Mutex::new(HashMap::new())),
             net_id_pool: Arc::new(Mutex::new(NetIdPool::new())),
+            events: EventStore::new(),
         }
     }
 
@@ -44,6 +47,9 @@ impl Orchestrator {
             .ip();
 
         self.clients.write().await.insert(client_ip, outbound);
+        self.events
+            .emit(Event::node_connected(client_ip.to_string()))
+            .await;
 
         let mut inbound = request.into_inner();
         let orchestrator = self.clone();
@@ -55,6 +61,10 @@ impl Orchestrator {
             }
 
             println!("Control channel from '{client_ip}' closed");
+            orchestrator
+                .events
+                .emit(Event::node_disconnected(client_ip.to_string()))
+                .await;
             orchestrator
                 .handle_node_disconnect(client_ip, &services)
                 .await;
@@ -83,7 +93,7 @@ impl Orchestrator {
                 continue;
             };
             let changes = detect_node_disconnect_changes(stack_map, client_ip);
-            apply_changes(changes, stack_map, None, self).await;
+            apply_changes(changes, stack_map, None, self, &stack).await;
         }
     }
 

--- a/members/nullnet-server/src/services/changes.rs
+++ b/members/nullnet-server/src/services/changes.rs
@@ -1,3 +1,4 @@
+use crate::events::Event;
 use crate::orchestrator::Orchestrator;
 use crate::services::clients::Client;
 use crate::services::service_info::ServiceInfo;
@@ -300,6 +301,14 @@ async fn teardown_chain(
                     *net_id,
                 )
                 .await;
+            orchestrator
+                .events
+                .emit(Event::session_torn_down(
+                    *net_id,
+                    name.to_string(),
+                    client_ip.to_string(),
+                ))
+                .await;
         }
     }
 }
@@ -559,10 +568,15 @@ pub(crate) async fn apply_changes(
     services: &mut HashMap<String, ServiceInfo>,
     loaded_services: Option<&HashMap<String, ServiceInfo>>,
     orchestrator: &Orchestrator,
+    stack: &str,
 ) {
     for change in changes {
         match change {
             ServiceChange::Removed { name } => {
+                orchestrator
+                    .events
+                    .emit(Event::service_unregistered(name.clone(), stack.to_string()))
+                    .await;
                 teardown_invalidated_service(&name, true, services, orchestrator).await;
                 services.remove(&name);
             }

--- a/members/nullnet-server/src/services/changes.rs
+++ b/members/nullnet-server/src/services/changes.rs
@@ -14,7 +14,7 @@ pub(crate) enum ServiceChange {
     /// Service's `triggers` changed in config.
     TriggersChanged { name: String },
     /// Service entry-point timeout toggled in config (Some ↔ None).
-    ReachabilityChanged { name: String },
+    ReachabilityChanged { name: String, now_reachable: bool },
     /// All replicas on a specific IP were removed (node disconnected).
     ReplicasRemoved { name: String, ip: IpAddr },
     /// A single replica was removed (host re-registered without this container).
@@ -83,7 +83,10 @@ pub(crate) fn detect_config_changes(
             }
             if loaded_info.timeout().is_some() != old_info.timeout().is_some() {
                 // reachability toggled (Some <-> None)
-                changes.push(ServiceChange::ReachabilityChanged { name: name.clone() });
+                changes.push(ServiceChange::ReachabilityChanged {
+                    name: name.clone(),
+                    now_reachable: loaded_info.timeout().is_some(),
+                });
             } else if let (Some(new_timeout), Some(old_timeout)) =
                 (loaded_info.timeout(), old_info.timeout())
                 && new_timeout != old_timeout
@@ -586,7 +589,18 @@ pub(crate) async fn apply_changes(
             ServiceChange::TriggersChanged { name } => {
                 teardown_all_backend_chains_for(&name, None, services, orchestrator).await;
             }
-            ServiceChange::ReachabilityChanged { name } => {
+            ServiceChange::ReachabilityChanged {
+                name,
+                now_reachable,
+            } => {
+                orchestrator
+                    .events
+                    .emit(Event::service_reachability_toggled(
+                        name.clone(),
+                        stack.to_string(),
+                        now_reachable,
+                    ))
+                    .await;
                 teardown_chain(&name, services, orchestrator, ProxyFilter::All).await;
                 teardown_all_backend_chains_for(&name, None, services, orchestrator).await;
             }
@@ -598,6 +612,14 @@ pub(crate) async fn apply_changes(
                 };
 
                 if is_last {
+                    orchestrator
+                        .events
+                        .emit(Event::all_replicas_removed(
+                            name.clone(),
+                            stack.to_string(),
+                            ip.to_string(),
+                        ))
+                        .await;
                     // Last replica gone — config-based cascade to transitive dependents
                     teardown_invalidated_service(&name, true, services, orchestrator).await;
                 } else {
@@ -689,6 +711,13 @@ pub(crate) async fn apply_changes(
                     "Proxy client '{}' timed out on service '{name}'",
                     client.display_name()
                 );
+                orchestrator
+                    .events
+                    .emit(Event::proxy_client_timed_out(
+                        name.clone(),
+                        client.display_name().to_string(),
+                    ))
+                    .await;
                 teardown_chain(
                     &name,
                     services,

--- a/members/nullnet-server/src/services/input.rs
+++ b/members/nullnet-server/src/services/input.rs
@@ -1,4 +1,5 @@
 use crate::env::TIMEOUT;
+use crate::events::Event as ServerEvent;
 use crate::orchestrator::Orchestrator;
 use crate::services::changes::{apply_changes, detect_config_changes};
 use crate::services::service_info::ServiceInfo;
@@ -196,7 +197,7 @@ pub(crate) async fn apply_config_update(
                 .into_iter()
                 .map(|name| crate::services::changes::ServiceChange::Removed { name })
                 .collect();
-            apply_changes(changes, stack_map, None, orchestrator).await;
+            apply_changes(changes, stack_map, None, orchestrator, &stack).await;
         }
         services.remove(&stack);
     }
@@ -204,9 +205,20 @@ pub(crate) async fn apply_config_update(
     // Stacks that exist in both: per-service diff. Then stacks new in config:
     // insert as empty maps and let the merge tail in apply_changes populate.
     for (stack, loaded_stack) in loaded_services {
-        let stack_map = services.entry(stack).or_default();
+        let stack_map = services.entry(stack.clone()).or_default();
         let changes = detect_config_changes(stack_map, &loaded_stack);
-        apply_changes(changes, stack_map, Some(&loaded_stack), orchestrator).await;
+        apply_changes(
+            changes,
+            stack_map,
+            Some(&loaded_stack),
+            orchestrator,
+            &stack,
+        )
+        .await;
+        orchestrator
+            .events
+            .emit(ServerEvent::config_reloaded(stack))
+            .await;
     }
 }
 

--- a/members/nullnet-server/src/services/input.rs
+++ b/members/nullnet-server/src/services/input.rs
@@ -189,6 +189,10 @@ pub(crate) async fn apply_config_update(
         .cloned()
         .collect();
     for stack in removed_stacks {
+        orchestrator
+            .events
+            .emit(ServerEvent::config_stack_removed(stack.clone()))
+            .await;
         if let Some(stack_map) = services.get_mut(&stack) {
             // Mark every service as removed so apply_changes tears down all
             // chains and replicas before we drop the stack entirely.

--- a/members/nullnet-server/src/services/service_info.rs
+++ b/members/nullnet-server/src/services/service_info.rs
@@ -52,6 +52,16 @@ impl ServiceInfo {
         }
     }
 
+    pub(crate) fn has_replica(&self, ip: IpAddr, docker_container: Option<&str>) -> bool {
+        match self {
+            ServiceInfo::Unregistered(_) => false,
+            ServiceInfo::Registered(reg) => reg
+                .replicas
+                .iter()
+                .any(|r| r.matches_identity(ip, docker_container)),
+        }
+    }
+
     /// Remove all replicas on the given IP.
     /// Transitions to `Unregistered` if no replicas remain.
     pub(crate) fn remove_replicas_on_ip(&mut self, ip: IpAddr) {

--- a/members/nullnet-server/src/tests.rs
+++ b/members/nullnet-server/src/tests.rs
@@ -742,7 +742,7 @@ async fn proxy_timeout_A() {
     tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
 
     let mut guard = server.services().write().await;
-    apply_timeouts(stack_view_mut(&mut guard), server.orchestrator()).await;
+    apply_timeouts(stack_view_mut(&mut guard), server.orchestrator(), "default").await;
     assert_graphviz(&guard, PROXY_TIMEOUT, "after_timeout_A.dot");
 
     // A is still registered but has no proxy clients
@@ -772,14 +772,14 @@ async fn proxy_timeout_A_then_B() {
     // A expires after 1s
     tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
     let mut guard = server.services().write().await;
-    apply_timeouts(stack_view_mut(&mut guard), server.orchestrator()).await;
+    apply_timeouts(stack_view_mut(&mut guard), server.orchestrator(), "default").await;
     assert_graphviz(&guard, PROXY_TIMEOUT, "after_timeout_A.dot");
     drop(guard);
 
     // B expires after 2s total
     tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
     let mut guard = server.services().write().await;
-    apply_timeouts(stack_view_mut(&mut guard), server.orchestrator()).await;
+    apply_timeouts(stack_view_mut(&mut guard), server.orchestrator(), "default").await;
     assert_graphviz(&guard, PROXY_TIMEOUT, "after_timeout_A_then_B.dot");
 
     // all services still registered, but no proxy clients left
@@ -806,7 +806,7 @@ async fn proxy_timeout_all_at_once() {
     tokio::time::sleep(std::time::Duration::from_millis(2100)).await;
 
     let mut guard = server.services().write().await;
-    apply_timeouts(stack_view_mut(&mut guard), server.orchestrator()).await;
+    apply_timeouts(stack_view_mut(&mut guard), server.orchestrator(), "default").await;
     assert_graphviz(&guard, PROXY_TIMEOUT, "after_timeout_all.dot");
 
     for (_, si) in stack_view(&guard).iter() {
@@ -1745,7 +1745,7 @@ async fn max_networks_reuse_lifecycle() {
 
     {
         let mut guard = server.services().write().await;
-        apply_timeouts(stack_view_mut(&mut guard), server.orchestrator()).await;
+        apply_timeouts(stack_view_mut(&mut guard), server.orchestrator(), "default").await;
         assert_graphviz(&guard, MAX_NETWORKS, "after_first_timeout.dot");
 
         let ServiceInfo::Registered(reg_a) = &stack_view(&guard)["A"] else {
@@ -1774,7 +1774,7 @@ async fn max_networks_reuse_lifecycle() {
 
     {
         let mut guard = server.services().write().await;
-        apply_timeouts(stack_view_mut(&mut guard), server.orchestrator()).await;
+        apply_timeouts(stack_view_mut(&mut guard), server.orchestrator(), "default").await;
         assert_graphviz(&guard, MAX_NETWORKS, "after_second_timeout.dot");
 
         let ServiceInfo::Registered(reg_a) = &stack_view(&guard)["A"] else {

--- a/members/nullnet-server/src/timeout.rs
+++ b/members/nullnet-server/src/timeout.rs
@@ -32,7 +32,7 @@ pub(crate) async fn check_timeouts(
         let stack_names: Vec<String> = services_mut.keys().cloned().collect();
         for stack in stack_names {
             if let Some(stack_map) = services_mut.get_mut(&stack) {
-                apply_timeouts(stack_map, &orchestrator).await;
+                apply_timeouts(stack_map, &orchestrator, &stack).await;
             }
         }
     }
@@ -41,10 +41,11 @@ pub(crate) async fn check_timeouts(
 pub(crate) async fn apply_timeouts(
     services: &mut HashMap<String, ServiceInfo>,
     orchestrator: &Orchestrator,
+    stack: &str,
 ) {
     let changes = collect_timed_out_clients(services);
     if !changes.is_empty() {
-        apply_changes(changes, services, None, orchestrator).await;
+        apply_changes(changes, services, None, orchestrator, stack).await;
     }
 }
 

--- a/members/nullnet-server/ui/src/App.tsx
+++ b/members/nullnet-server/ui/src/App.tsx
@@ -6,6 +6,7 @@ import Nodes from './pages/Nodes';
 import Sessions from './pages/Sessions';
 import Pool from './pages/Pool';
 import Config from './pages/Config';
+import Events from './pages/Events';
 
 export default function App() {
   return (
@@ -18,6 +19,7 @@ export default function App() {
           <Route path="/sessions" element={<Sessions />} />
           <Route path="/pool" element={<Pool />} />
           <Route path="/config" element={<Config />} />
+          <Route path="/events" element={<Events />} />
         </Routes>
       </BrowserRouter>
     </StackProvider>

--- a/members/nullnet-server/ui/src/components/Layout.tsx
+++ b/members/nullnet-server/ui/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { useStack } from '../StackContext';
 import { useApi } from '../hooks/useApi';
 import type { SessionJson } from '../types';
 
-type Page = 'dashboard' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config';
+type Page = 'dashboard' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config' | 'events';
 
 interface Props {
   page: Page;
@@ -31,7 +31,7 @@ const NAV = [
   {
     group: 'Ops',
     items: [
-      { id: 'events', icon: '≡', label: 'Events', to: null },
+      { id: 'events', icon: '≡', label: 'Events', to: '/events' },
       { id: 'config', icon: '⚙', label: 'Config', to: '/config' },
     ],
   },

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -1,30 +1,15 @@
 import { useState, useEffect, useRef } from 'react';
 import Layout from '../components/Layout';
-import type { EventJson } from '../types';
+import type { EventJson, Severity } from '../types';
 
-const KIND_COLORS: Record<string, string> = {
-  node_connected: 'var(--green)',
-  node_disconnected: 'var(--amber)',
-  service_registered: 'var(--cyan)',
-  service_unregistered: 'var(--amber)',
-  setup_started: 'var(--blue)',
-  setup_ack: 'var(--green)',
-  setup_timeout: 'var(--red, #f87171)',
-  session_created: 'var(--green)',
-  session_torn_down: 'var(--t2)',
-  config_reloaded: 'var(--cyan)',
-  config_stack_removed: 'var(--amber)',
-  all_replicas_removed: 'var(--red, #f87171)',
-  service_reachability_toggled: 'var(--cyan)',
-  proxy_client_timed_out: 'var(--amber)',
-  sticky_session_reused: 'var(--t2)',
-  max_networks_limit_enforced: 'var(--amber)',
-  net_id_pool_exhausted: 'var(--red, #f87171)',
-  proxy_chain_setup_failed: 'var(--red, #f87171)',
-  backend_trigger_setup_bailed: 'var(--amber)',
+const SEVERITY_COLOR: Record<Severity, string> = {
+  info: 'var(--green)',
+  warning: 'var(--amber)',
+  error: 'var(--red, #f87171)',
 };
 
 const KIND_LABELS: Record<string, string> = {
+  // Server events
   node_connected: 'node_connected',
   node_disconnected: 'node_disconnected',
   service_registered: 'service_registered',
@@ -44,6 +29,32 @@ const KIND_LABELS: Record<string, string> = {
   net_id_pool_exhausted: 'net_id_pool_exhausted',
   proxy_chain_setup_failed: 'proxy_chain_setup_failed',
   backend_trigger_setup_bailed: 'backend_trigger_setup_bailed',
+  // Client error
+  vxlan_setup_failed: 'vxlan_setup_failed',
+  vlan_setup_failed: 'vlan_setup_failed',
+  vxlan_teardown_failed: 'vxlan_teardown_failed',
+  vlan_teardown_failed: 'vlan_teardown_failed',
+  dnat_install_failed: 'dnat_install_failed',
+  dnat_removal_failed: 'dnat_removal_failed',
+  host_mapping_failed: 'host_mapping_failed',
+  control_channel_closed: 'control_channel_closed',
+  control_channel_ack_failed: 'control_channel_ack_failed',
+  services_list_update_failed: 'services_list_update_failed',
+  backend_trigger_send_failed: 'backend_trigger_send_failed',
+  firewall_rules_load_failed: 'firewall_rules_load_failed',
+  // Client info
+  vxlan_setup_completed: 'vxlan_setup_completed',
+  vlan_setup_completed: 'vlan_setup_completed',
+  control_channel_established: 'control_channel_established',
+  services_list_updated: 'services_list_updated',
+  // Proxy error
+  upstream_lookup_failed: 'upstream_lookup_failed',
+  proxy_request_missing_host: 'proxy_request_missing_host',
+  proxy_request_invalid_host: 'proxy_request_invalid_host',
+  upstream_ip_parse_failed: 'upstream_ip_parse_failed',
+  proxy_client_not_inet: 'proxy_client_not_inet',
+  // Proxy info
+  proxy_request_routed: 'proxy_request_routed',
 };
 
 const ALL_KINDS = Object.keys(KIND_LABELS);
@@ -67,7 +78,6 @@ function eventDetail(e: EventJson): string {
     case 'session_torn_down':
       return `net ${e.net_id} · ${e.service} · ${e.client_ip}`;
     case 'config_reloaded':
-      return e.stack;
     case 'config_stack_removed':
       return e.stack;
     case 'all_replicas_removed':
@@ -81,11 +91,55 @@ function eventDetail(e: EventJson): string {
     case 'max_networks_limit_enforced':
       return `${e.service} · proxy ${e.proxy_ip} · net ${e.net_id} · limit ${e.limit}`;
     case 'net_id_pool_exhausted':
-      return `${e.service} · ${e.client_ip}`;
     case 'proxy_chain_setup_failed':
       return `${e.service} · ${e.client_ip}`;
     case 'backend_trigger_setup_bailed':
       return `${e.service} · port ${e.port}`;
+    // Client error
+    case 'vxlan_setup_failed':
+    case 'vxlan_teardown_failed':
+      return `vxlan ${e.vxlan_id} · ${e.ns_name} · code ${e.error_code}`;
+    case 'vlan_setup_failed':
+      return `vlan ${e.vlan_id} · ${e.local_veth} · ${e.error_reason}`;
+    case 'vlan_teardown_failed':
+      return `vlan ${e.vlan_id} · ${e.error_reason}`;
+    case 'dnat_install_failed':
+    case 'dnat_removal_failed':
+      return `port ${e.port} → ${e.overlay_ip}`;
+    case 'host_mapping_failed':
+      return `${e.hostname} → ${e.ip}${e.docker_container ? ` (${e.docker_container})` : ''}`;
+    case 'control_channel_closed':
+      return '—';
+    case 'control_channel_ack_failed':
+      return `${e.message_type} · msg ${e.msg_id}`;
+    case 'services_list_update_failed':
+      return `${e.num_services} services · ${e.error_message}`;
+    case 'backend_trigger_send_failed':
+      return `${e.service_name} · port ${e.port} · ${e.error_message}`;
+    case 'firewall_rules_load_failed':
+      return `${e.path} · ${e.error_message}`;
+    // Client info
+    case 'vxlan_setup_completed':
+      return `vxlan ${e.vxlan_id} · ${e.ns_name}`;
+    case 'vlan_setup_completed':
+      return `vlan ${e.vlan_id}`;
+    case 'control_channel_established':
+      return '—';
+    case 'services_list_updated':
+      return `${e.num_services} services`;
+    // Proxy error
+    case 'upstream_lookup_failed':
+      return `${e.service_name} · ${e.client_ip} · ${e.error_message}`;
+    case 'proxy_request_missing_host':
+    case 'proxy_request_invalid_host':
+      return e.client_ip;
+    case 'upstream_ip_parse_failed':
+      return `${e.raw_ip} · ${e.service_name}`;
+    case 'proxy_client_not_inet':
+      return e.address_family;
+    // Proxy info
+    case 'proxy_request_routed':
+      return `${e.service_name} · ${e.client_ip} → ${e.upstream_ip} · ${e.latency_ms}ms`;
   }
 }
 
@@ -94,17 +148,18 @@ function formatTs(unix: number): string {
 }
 
 const MAX_EVENTS = 500;
+const SEVERITIES: Severity[] = ['info', 'warning', 'error'];
 
 export default function Events() {
   const [events, setEvents] = useState<EventJson[]>([]);
-  const [filter, setFilter] = useState<string>('');
+  const [kindFilter, setKindFilter] = useState<string>('');
+  const [severityFilter, setSeverityFilter] = useState<Severity | ''>('');
   const [paused, setPaused] = useState(false);
   const [liveCount, setLiveCount] = useState(0);
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
 
   useEffect(() => {
-    // Initial load from REST endpoint
     fetch('/api/events')
       .then(r => r.json())
       .then((data: EventJson[]) => setEvents(data))
@@ -132,16 +187,29 @@ export default function Events() {
     return () => es.close();
   }, []);
 
-  const filtered = (filter ? events.filter(e => e.type === filter) : events)
+  const filtered = events
+    .filter(e => !kindFilter || e.type === kindFilter)
+    .filter(e => !severityFilter || e.severity === severityFilter)
     .slice()
     .reverse();
+
+  const chipStyle = (active: boolean, color: string) => ({
+    background: active ? color : 'var(--s1)',
+    border: `1px solid ${active ? color : 'var(--border)'}`,
+    color: active ? 'var(--bg, #0a0a0a)' : 'var(--t2)',
+    borderRadius: 4,
+    padding: '2px 10px',
+    fontSize: 11,
+    cursor: 'pointer',
+    fontWeight: active ? 600 : 400,
+  });
 
   return (
     <Layout
       page="events"
       topbarRight={
         <span className="live-row">
-          <span className={`live-dot${paused ? '' : ''}`} style={{ background: paused ? 'var(--t3)' : 'var(--green)' }}></span>
+          <span style={{ width: 6, height: 6, borderRadius: '50%', display: 'inline-block', background: paused ? 'var(--t3)' : 'var(--green)', marginRight: 5 }} />
           {paused ? 'paused' : `live · ${liveCount} received`}
         </span>
       }
@@ -149,16 +217,36 @@ export default function Events() {
       <div className="content">
         <div className="hero-row">
           <span className="hero-num">{filtered.length}</span>
-          <span className="hero-label">{filter ? `${filter} events` : 'events in buffer'}</span>
+          <span className="hero-label">
+            {kindFilter ? `${kindFilter} events` : severityFilter ? `${severityFilter} events` : 'events in buffer'}
+          </span>
         </div>
 
         <div className="card">
           <div className="card-head" style={{ gap: 8, flexWrap: 'wrap' }}>
             <span className="card-label">Event Stream</span>
             <div style={{ display: 'flex', gap: 6, flex: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+              {/* Severity chips */}
+              <button style={chipStyle(severityFilter === '', 'var(--t2)')} onClick={() => setSeverityFilter('')}>
+                All
+              </button>
+              {SEVERITIES.map(s => (
+                <button
+                  key={s}
+                  style={chipStyle(severityFilter === s, SEVERITY_COLOR[s])}
+                  onClick={() => setSeverityFilter(prev => prev === s ? '' : s)}
+                >
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+
+              {/* Divider */}
+              <span style={{ width: 1, height: 16, background: 'var(--border)', margin: '0 2px' }} />
+
+              {/* Kind dropdown */}
               <select
-                value={filter}
-                onChange={e => setFilter(e.target.value)}
+                value={kindFilter}
+                onChange={e => setKindFilter(e.target.value)}
                 style={{
                   background: 'var(--s1)',
                   border: '1px solid var(--border)',
@@ -174,6 +262,7 @@ export default function Events() {
                   <option key={k} value={k}>{KIND_LABELS[k]}</option>
                 ))}
               </select>
+
               <button
                 onClick={() => setPaused(p => !p)}
                 style={{
@@ -212,7 +301,7 @@ export default function Events() {
               <thead>
                 <tr>
                   <th style={{ width: 72 }}>Time</th>
-                  <th style={{ width: 180 }}>Type</th>
+                  <th style={{ width: 200 }}>Type</th>
                   <th>Detail</th>
                 </tr>
               </thead>
@@ -220,7 +309,9 @@ export default function Events() {
                 {filtered.length === 0 && (
                   <tr>
                     <td colSpan={3} style={{ color: 'var(--t2)', padding: '20px 16px' }}>
-                      {filter ? `No ${filter} events` : 'No events yet — waiting for activity…'}
+                      {kindFilter || severityFilter
+                        ? 'No matching events'
+                        : 'No events yet — waiting for activity…'}
                     </td>
                   </tr>
                 )}
@@ -234,7 +325,7 @@ export default function Events() {
                         style={{
                           fontFamily: "'JetBrains Mono',monospace",
                           fontSize: 11,
-                          color: KIND_COLORS[e.type] ?? 'var(--t1)',
+                          color: SEVERITY_COLOR[e.severity],
                           fontWeight: 500,
                         }}
                       >

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -1,0 +1,229 @@
+import { useState, useEffect, useRef } from 'react';
+import Layout from '../components/Layout';
+import type { EventJson } from '../types';
+
+const KIND_COLORS: Record<string, string> = {
+  node_connected: 'var(--green)',
+  node_disconnected: 'var(--amber)',
+  service_registered: 'var(--cyan)',
+  service_unregistered: 'var(--amber)',
+  setup_started: 'var(--blue)',
+  setup_ack: 'var(--green)',
+  setup_timeout: 'var(--red, #f87171)',
+  session_created: 'var(--green)',
+  session_torn_down: 'var(--t2)',
+  config_reloaded: 'var(--cyan)',
+};
+
+const KIND_LABELS: Record<string, string> = {
+  node_connected: 'node_connected',
+  node_disconnected: 'node_disconnected',
+  service_registered: 'service_registered',
+  service_unregistered: 'service_unregistered',
+  setup_started: 'setup_started',
+  setup_ack: 'setup_ack',
+  setup_timeout: 'setup_timeout',
+  session_created: 'session_created',
+  session_torn_down: 'session_torn_down',
+  config_reloaded: 'config_reloaded',
+};
+
+const ALL_KINDS = Object.keys(KIND_LABELS);
+
+function eventDetail(e: EventJson): string {
+  switch (e.type) {
+    case 'node_connected':
+    case 'node_disconnected':
+      return e.ip;
+    case 'service_registered':
+    case 'service_unregistered':
+      return `${e.name} · ${e.stack}`;
+    case 'setup_started':
+      return `net ${e.net_id} · ${e.service} ← ${e.client_ip}`;
+    case 'setup_ack':
+      return `net ${e.net_id} · ${e.service} · ${e.latency_ms}ms`;
+    case 'setup_timeout':
+      return `net ${e.net_id} · ${e.service}`;
+    case 'session_created':
+      return `net ${e.net_id} · ${e.service} ← ${e.client_ip}`;
+    case 'session_torn_down':
+      return `net ${e.net_id} · ${e.service} · ${e.client_ip}`;
+    case 'config_reloaded':
+      return e.stack;
+  }
+}
+
+function formatTs(unix: number): string {
+  return new Date(unix * 1000).toLocaleTimeString([], { hour12: false });
+}
+
+const MAX_EVENTS = 500;
+
+export default function Events() {
+  const [events, setEvents] = useState<EventJson[]>([]);
+  const [filter, setFilter] = useState<string>('');
+  const [paused, setPaused] = useState(false);
+  const [liveCount, setLiveCount] = useState(0);
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Initial load from REST endpoint
+    fetch('/api/events')
+      .then(r => r.json())
+      .then((data: EventJson[]) => setEvents(data))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const es = new EventSource('/api/events/stream');
+
+    es.onmessage = (ev) => {
+      try {
+        const event: EventJson = JSON.parse(ev.data);
+        if (!pausedRef.current) {
+          setEvents(prev => {
+            const next = [...prev, event];
+            return next.length > MAX_EVENTS ? next.slice(next.length - MAX_EVENTS) : next;
+          });
+          setLiveCount(c => c + 1);
+        }
+      } catch {
+        // ignore malformed
+      }
+    };
+
+    return () => es.close();
+  }, []);
+
+  // Auto-scroll to bottom when new events arrive (unless paused)
+  useEffect(() => {
+    if (!paused) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [events, paused]);
+
+  const filtered = filter
+    ? events.filter(e => e.type === filter)
+    : events;
+
+  return (
+    <Layout
+      page="events"
+      topbarRight={
+        <span className="live-row">
+          <span className={`live-dot${paused ? '' : ''}`} style={{ background: paused ? 'var(--t3)' : 'var(--green)' }}></span>
+          {paused ? 'paused' : `live · ${liveCount} received`}
+        </span>
+      }
+    >
+      <div className="content">
+        <div className="hero-row">
+          <span className="hero-num">{filtered.length}</span>
+          <span className="hero-label">{filter ? `${filter} events` : 'events in buffer'}</span>
+        </div>
+
+        <div className="card">
+          <div className="card-head" style={{ gap: 8, flexWrap: 'wrap' }}>
+            <span className="card-label">Event Stream</span>
+            <div style={{ display: 'flex', gap: 6, flex: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+              <select
+                value={filter}
+                onChange={e => setFilter(e.target.value)}
+                style={{
+                  background: 'var(--s1)',
+                  border: '1px solid var(--border)',
+                  color: 'var(--t1)',
+                  borderRadius: 4,
+                  padding: '2px 6px',
+                  fontSize: 11,
+                  cursor: 'pointer',
+                }}
+              >
+                <option value="">All types</option>
+                {ALL_KINDS.map(k => (
+                  <option key={k} value={k}>{KIND_LABELS[k]}</option>
+                ))}
+              </select>
+              <button
+                onClick={() => setPaused(p => !p)}
+                style={{
+                  background: paused ? 'var(--blue)' : 'var(--s1)',
+                  border: '1px solid var(--border)',
+                  color: 'var(--t1)',
+                  borderRadius: 4,
+                  padding: '2px 10px',
+                  fontSize: 11,
+                  cursor: 'pointer',
+                }}
+              >
+                {paused ? 'Resume' : 'Pause'}
+              </button>
+              {filtered.length > 0 && (
+                <button
+                  onClick={() => setEvents([])}
+                  style={{
+                    background: 'var(--s1)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--t2)',
+                    borderRadius: 4,
+                    padding: '2px 10px',
+                    fontSize: 11,
+                    cursor: 'pointer',
+                  }}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div style={{ overflowY: 'auto', maxHeight: 520 }}>
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th style={{ width: 72 }}>Time</th>
+                  <th style={{ width: 180 }}>Type</th>
+                  <th>Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.length === 0 && (
+                  <tr>
+                    <td colSpan={3} style={{ color: 'var(--t2)', padding: '20px 16px' }}>
+                      {filter ? `No ${filter} events` : 'No events yet — waiting for activity…'}
+                    </td>
+                  </tr>
+                )}
+                {filtered.map((e, i) => (
+                  <tr key={i}>
+                    <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 10, color: 'var(--t2)', whiteSpace: 'nowrap' }}>
+                      {formatTs(e.timestamp)}
+                    </td>
+                    <td>
+                      <span
+                        style={{
+                          fontFamily: "'JetBrains Mono',monospace",
+                          fontSize: 11,
+                          color: KIND_COLORS[e.type] ?? 'var(--t1)',
+                          fontWeight: 500,
+                        }}
+                      >
+                        {e.type}
+                      </span>
+                    </td>
+                    <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: 'var(--t1)' }}>
+                      {eventDetail(e)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div ref={bottomRef} />
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -102,7 +102,6 @@ export default function Events() {
   const [liveCount, setLiveCount] = useState(0);
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
-  const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // Initial load from REST endpoint
@@ -133,16 +132,9 @@ export default function Events() {
     return () => es.close();
   }, []);
 
-  // Auto-scroll to bottom when new events arrive (unless paused)
-  useEffect(() => {
-    if (!paused) {
-      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [events, paused]);
-
-  const filtered = filter
-    ? events.filter(e => e.type === filter)
-    : events;
+  const filtered = (filter ? events.filter(e => e.type === filter) : events)
+    .slice()
+    .reverse();
 
   return (
     <Layout
@@ -256,7 +248,6 @@ export default function Events() {
                 ))}
               </tbody>
             </table>
-            <div ref={bottomRef} />
           </div>
         </div>
       </div>

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -13,6 +13,15 @@ const KIND_COLORS: Record<string, string> = {
   session_created: 'var(--green)',
   session_torn_down: 'var(--t2)',
   config_reloaded: 'var(--cyan)',
+  config_stack_removed: 'var(--amber)',
+  all_replicas_removed: 'var(--red, #f87171)',
+  service_reachability_toggled: 'var(--cyan)',
+  proxy_client_timed_out: 'var(--amber)',
+  sticky_session_reused: 'var(--t2)',
+  max_networks_limit_enforced: 'var(--amber)',
+  net_id_pool_exhausted: 'var(--red, #f87171)',
+  proxy_chain_setup_failed: 'var(--red, #f87171)',
+  backend_trigger_setup_bailed: 'var(--amber)',
 };
 
 const KIND_LABELS: Record<string, string> = {
@@ -26,6 +35,15 @@ const KIND_LABELS: Record<string, string> = {
   session_created: 'session_created',
   session_torn_down: 'session_torn_down',
   config_reloaded: 'config_reloaded',
+  config_stack_removed: 'config_stack_removed',
+  all_replicas_removed: 'all_replicas_removed',
+  service_reachability_toggled: 'service_reachability_toggled',
+  proxy_client_timed_out: 'proxy_client_timed_out',
+  sticky_session_reused: 'sticky_session_reused',
+  max_networks_limit_enforced: 'max_networks_limit_enforced',
+  net_id_pool_exhausted: 'net_id_pool_exhausted',
+  proxy_chain_setup_failed: 'proxy_chain_setup_failed',
+  backend_trigger_setup_bailed: 'backend_trigger_setup_bailed',
 };
 
 const ALL_KINDS = Object.keys(KIND_LABELS);
@@ -50,6 +68,24 @@ function eventDetail(e: EventJson): string {
       return `net ${e.net_id} · ${e.service} · ${e.client_ip}`;
     case 'config_reloaded':
       return e.stack;
+    case 'config_stack_removed':
+      return e.stack;
+    case 'all_replicas_removed':
+      return `${e.service} · ${e.stack} · ${e.ip}`;
+    case 'service_reachability_toggled':
+      return `${e.service} · ${e.stack} · ${e.reachable ? 'reachable' : 'unreachable'}`;
+    case 'proxy_client_timed_out':
+      return `${e.service} · ${e.client_ip}`;
+    case 'sticky_session_reused':
+      return `${e.service} · ${e.client_ip} via ${e.proxy_ip}`;
+    case 'max_networks_limit_enforced':
+      return `${e.service} · proxy ${e.proxy_ip} · net ${e.net_id} · limit ${e.limit}`;
+    case 'net_id_pool_exhausted':
+      return `${e.service} · ${e.client_ip}`;
+    case 'proxy_chain_setup_failed':
+      return `${e.service} · ${e.client_ip}`;
+    case 'backend_trigger_setup_bailed':
+      return `${e.service} · port ${e.port}`;
   }
 }
 

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -160,13 +160,6 @@ export default function Events() {
   pausedRef.current = paused;
 
   useEffect(() => {
-    fetch('/api/events')
-      .then(r => r.json())
-      .then((data: EventJson[]) => setEvents(data))
-      .catch(() => {});
-  }, []);
-
-  useEffect(() => {
     const es = new EventSource('/api/events/stream');
 
     es.onmessage = (ev) => {

--- a/members/nullnet-server/ui/src/types.ts
+++ b/members/nullnet-server/ui/src/types.ts
@@ -46,23 +46,54 @@ export interface SessionJson {
   created_at: number;
 }
 
+export type Severity = 'info' | 'warning' | 'error';
+
+type WithSeverity = { severity: Severity; timestamp: number };
+
 export type EventJson =
-  | { type: 'node_connected'; ip: string; timestamp: number }
-  | { type: 'node_disconnected'; ip: string; timestamp: number }
-  | { type: 'service_registered'; name: string; stack: string; timestamp: number }
-  | { type: 'service_unregistered'; name: string; stack: string; timestamp: number }
-  | { type: 'setup_started'; net_id: number; service: string; client_ip: string; timestamp: number }
-  | { type: 'setup_ack'; net_id: number; service: string; latency_ms: number; timestamp: number }
-  | { type: 'setup_timeout'; net_id: number; service: string; timestamp: number }
-  | { type: 'session_created'; net_id: number; service: string; client_ip: string; timestamp: number }
-  | { type: 'session_torn_down'; net_id: number; service: string; client_ip: string; timestamp: number }
-  | { type: 'config_reloaded'; stack: string; timestamp: number }
-  | { type: 'config_stack_removed'; stack: string; timestamp: number }
-  | { type: 'all_replicas_removed'; service: string; stack: string; ip: string; timestamp: number }
-  | { type: 'service_reachability_toggled'; service: string; stack: string; reachable: boolean; timestamp: number }
-  | { type: 'proxy_client_timed_out'; service: string; client_ip: string; timestamp: number }
-  | { type: 'sticky_session_reused'; service: string; client_ip: string; proxy_ip: string; timestamp: number }
-  | { type: 'max_networks_limit_enforced'; service: string; proxy_ip: string; net_id: number; limit: number; timestamp: number }
-  | { type: 'net_id_pool_exhausted'; service: string; client_ip: string; timestamp: number }
-  | { type: 'proxy_chain_setup_failed'; service: string; client_ip: string; timestamp: number }
-  | { type: 'backend_trigger_setup_bailed'; service: string; port: number; timestamp: number };
+  // Existing server events
+  | WithSeverity & { type: 'node_connected'; ip: string }
+  | WithSeverity & { type: 'node_disconnected'; ip: string }
+  | WithSeverity & { type: 'service_registered'; name: string; stack: string }
+  | WithSeverity & { type: 'service_unregistered'; name: string; stack: string }
+  | WithSeverity & { type: 'setup_started'; net_id: number; service: string; client_ip: string }
+  | WithSeverity & { type: 'setup_ack'; net_id: number; service: string; latency_ms: number }
+  | WithSeverity & { type: 'setup_timeout'; net_id: number; service: string }
+  | WithSeverity & { type: 'session_created'; net_id: number; service: string; client_ip: string }
+  | WithSeverity & { type: 'session_torn_down'; net_id: number; service: string; client_ip: string }
+  | WithSeverity & { type: 'config_reloaded'; stack: string }
+  | WithSeverity & { type: 'config_stack_removed'; stack: string }
+  | WithSeverity & { type: 'all_replicas_removed'; service: string; stack: string; ip: string }
+  | WithSeverity & { type: 'service_reachability_toggled'; service: string; stack: string; reachable: boolean }
+  | WithSeverity & { type: 'proxy_client_timed_out'; service: string; client_ip: string }
+  | WithSeverity & { type: 'sticky_session_reused'; service: string; client_ip: string; proxy_ip: string }
+  | WithSeverity & { type: 'max_networks_limit_enforced'; service: string; proxy_ip: string; net_id: number; limit: number }
+  | WithSeverity & { type: 'net_id_pool_exhausted'; service: string; client_ip: string }
+  | WithSeverity & { type: 'proxy_chain_setup_failed'; service: string; client_ip: string }
+  | WithSeverity & { type: 'backend_trigger_setup_bailed'; service: string; port: number }
+  // Client error events
+  | WithSeverity & { type: 'vxlan_setup_failed'; vxlan_id: number; ns_name: string; error_code: number }
+  | WithSeverity & { type: 'vlan_setup_failed'; vlan_id: number; local_veth: string; error_reason: string }
+  | WithSeverity & { type: 'vxlan_teardown_failed'; vxlan_id: number; ns_name: string; error_code: number }
+  | WithSeverity & { type: 'vlan_teardown_failed'; vlan_id: number; error_reason: string }
+  | WithSeverity & { type: 'dnat_install_failed'; port: number; overlay_ip: string }
+  | WithSeverity & { type: 'dnat_removal_failed'; port: number; overlay_ip: string }
+  | WithSeverity & { type: 'host_mapping_failed'; hostname: string; ip: string; docker_container?: string }
+  | WithSeverity & { type: 'control_channel_closed' }
+  | WithSeverity & { type: 'control_channel_ack_failed'; msg_id: string; message_type: string }
+  | WithSeverity & { type: 'services_list_update_failed'; error_message: string; num_services: number }
+  | WithSeverity & { type: 'backend_trigger_send_failed'; service_name: string; port: number; error_message: string }
+  | WithSeverity & { type: 'firewall_rules_load_failed'; path: string; error_message: string }
+  // Client info events
+  | WithSeverity & { type: 'vxlan_setup_completed'; vxlan_id: number; ns_name: string }
+  | WithSeverity & { type: 'vlan_setup_completed'; vlan_id: number }
+  | WithSeverity & { type: 'control_channel_established' }
+  | WithSeverity & { type: 'services_list_updated'; num_services: number }
+  // Proxy error events
+  | WithSeverity & { type: 'upstream_lookup_failed'; service_name: string; client_ip: string; error_message: string }
+  | WithSeverity & { type: 'proxy_request_missing_host'; client_ip: string }
+  | WithSeverity & { type: 'proxy_request_invalid_host'; client_ip: string }
+  | WithSeverity & { type: 'upstream_ip_parse_failed'; raw_ip: string; service_name: string }
+  | WithSeverity & { type: 'proxy_client_not_inet'; address_family: string }
+  // Proxy info events
+  | WithSeverity & { type: 'proxy_request_routed'; service_name: string; client_ip: string; upstream_ip: string; latency_ms: number };

--- a/members/nullnet-server/ui/src/types.ts
+++ b/members/nullnet-server/ui/src/types.ts
@@ -56,4 +56,13 @@ export type EventJson =
   | { type: 'setup_timeout'; net_id: number; service: string; timestamp: number }
   | { type: 'session_created'; net_id: number; service: string; client_ip: string; timestamp: number }
   | { type: 'session_torn_down'; net_id: number; service: string; client_ip: string; timestamp: number }
-  | { type: 'config_reloaded'; stack: string; timestamp: number };
+  | { type: 'config_reloaded'; stack: string; timestamp: number }
+  | { type: 'config_stack_removed'; stack: string; timestamp: number }
+  | { type: 'all_replicas_removed'; service: string; stack: string; ip: string; timestamp: number }
+  | { type: 'service_reachability_toggled'; service: string; stack: string; reachable: boolean; timestamp: number }
+  | { type: 'proxy_client_timed_out'; service: string; client_ip: string; timestamp: number }
+  | { type: 'sticky_session_reused'; service: string; client_ip: string; proxy_ip: string; timestamp: number }
+  | { type: 'max_networks_limit_enforced'; service: string; proxy_ip: string; net_id: number; limit: number; timestamp: number }
+  | { type: 'net_id_pool_exhausted'; service: string; client_ip: string; timestamp: number }
+  | { type: 'proxy_chain_setup_failed'; service: string; client_ip: string; timestamp: number }
+  | { type: 'backend_trigger_setup_bailed'; service: string; port: number; timestamp: number };

--- a/members/nullnet-server/ui/src/types.ts
+++ b/members/nullnet-server/ui/src/types.ts
@@ -45,3 +45,15 @@ export interface SessionJson {
   chain_depth: number;
   created_at: number;
 }
+
+export type EventJson =
+  | { type: 'node_connected'; ip: string; timestamp: number }
+  | { type: 'node_disconnected'; ip: string; timestamp: number }
+  | { type: 'service_registered'; name: string; stack: string; timestamp: number }
+  | { type: 'service_unregistered'; name: string; stack: string; timestamp: number }
+  | { type: 'setup_started'; net_id: number; service: string; client_ip: string; timestamp: number }
+  | { type: 'setup_ack'; net_id: number; service: string; latency_ms: number; timestamp: number }
+  | { type: 'setup_timeout'; net_id: number; service: string; timestamp: number }
+  | { type: 'session_created'; net_id: number; service: string; client_ip: string; timestamp: number }
+  | { type: 'session_torn_down'; net_id: number; service: string; client_ip: string; timestamp: number }
+  | { type: 'config_reloaded'; stack: string; timestamp: number };


### PR DESCRIPTION
## Summary

Adds a complete structured event system to nullnet — a server-side EventStore exposed
via REST and SSE, 41 strongly-typed event variants covering the server, agent, and proxy,
event severity levels, and a live React Events page with type and severity filtering.

---

### EventStore (server)

A ring-buffer + broadcast-channel store (`Arc<Mutex<VecDeque<Event>>>` +
`broadcast::Sender<Event>`) wired into the server orchestrator. Two HTTP endpoints:

- `GET /api/events` — snapshot of the buffer; accepts `?limit=`, `?kind=`, `?severity=`
- `GET /api/events/stream` — SSE stream; sends full backfill on connect then live events

Events are stored as a closed Rust enum; serialization uses an `EventEnvelope<'a>`
wrapper that flattens a `severity` field into the existing per-variant JSON:

```json
{"type": "vxlan_setup_failed", "severity": "error", "vxlan_id": 5, ...}
```

### 41 event variants across three sources

**Server — lifecycle (10)**

| Event | When |
|-------|------|
| `NodeConnected` | Agent establishes gRPC stream |
| `NodeDisconnected` | Stream closes |
| `ServiceRegistered` | First replica of a service appears |
| `ServiceUnregistered` | Last replica removed |
| `SetupStarted` / `SetupAck` / `SetupTimeout` | VXLAN setup handshake |
| `SessionCreated` / `SessionTornDown` | Per-connection sessions |
| `ConfigReloaded` | SIGHUP / config reload |

**Server — operational (9)**

| Event | When |
|-------|------|
| `NetIdPoolExhausted` | No free net IDs for a new session |
| `ProxyChainSetupFailed` | Proxy-chain configuration error |
| `StickySessionReused` | Sticky session hit for a client |
| `MaxNetworksLimitEnforced` | Network limit reached for a node |
| `ProxyClientTimedOut` | Client timed out waiting for proxy |
| `AllReplicasRemoved` | All replicas of a service removed |
| `ServiceReachabilityToggled` | Service becomes reachable / unreachable |
| `BackendTriggerSetupBailed` | Backend trigger task aborted |
| `ConfigStackRemoved` | Config stack cleaned up on disconnect |

**Client — error (12)**

`VxlanSetupFailed`, `VlanSetupFailed`, `VxlanTeardownFailed`, `VlanTeardownFailed`,
`DnatInstallFailed`, `DnatRemovalFailed`, `HostMappingFailed`, `ControlChannelClosed`,
`ControlChannelAckFailed`, `ServicesListUpdateFailed`, `BackendTriggerSendFailed`,
`FirewallRulesLoadFailed`

**Client — info (4)**

`ControlChannelEstablished`, `VxlanSetupCompleted`, `VlanSetupCompleted`,
`ServicesListUpdated`

`ServicesListUpdated` fires only when the declared service set actually changes
(sorted comparison against a `last_declared` snapshot), so steady-state 10 s polls
stay silent.

**Proxy — error (5)**

`UpstreamLookupFailed`, `ProxyRequestMissingHost`, `ProxyRequestInvalidHost`,
`UpstreamIpParseFailed`, `ProxyClientNotInet`

**Proxy — info (1)**

`ProxyRequestRouted` — emitted on every successfully routed request

### Client/proxy transport: `ReportEvent` gRPC RPC

A new unary `ReportEvent(AgentEvent) returns (Empty)` is added to `NullnetGrpc`.
`AgentEvent` is a proto `oneof` with 22 strongly-typed sub-messages (one per
client/proxy variant). The server maps each arm to the `Event` enum and emits to the
`EventStore`.

Both client and proxy call it fire-and-forget (`tokio::spawn`) via a `fire_event`
helper, so event reporting never touches the hot path or propagates errors.

### Severity

Every event carries a `Severity` level:

| Level | Assigned to |
|-------|-------------|
| `info` | Normal operations: connections, successful setups, sessions, routed requests |
| `warning` | Degraded-but-non-fatal: disconnects, timeouts, reachability toggles, channel closed |
| `error` | All failure events from client and proxy |

`Severity` is a first-class Rust enum with a `severity()` method on `Event`.

### Events UI

- Live React page at `/events` subscribes to the SSE stream
- Per-type filter dropdown covering all 41 variant types
- Severity filter chips — **All / Info / Warning / Error** — combinable with the type filter
---
