### PR TITLE
add Topology page

### DIFF
--- a/members/nullnet-server/src/http_server/sessions.rs
+++ b/members/nullnet-server/src/http_server/sessions.rs
@@ -34,11 +34,11 @@ pub(super) async fn list_handler(State(state): State<AppState>) -> impl IntoResp
                 reg.all_clients_owned()
                     .into_iter()
                     .filter_map(|(c, ci, _, _)| {
-                        let proxy_ip = c.is_proxy()?;
+                        c.is_proxy()?;
                         Some(SessionJson {
                             id: ci.net_id(),
                             network_id: ci.net_id(),
-                            client_ip: proxy_ip.to_string(),
+                            client_ip: c.name().to_string(),
                             client_net: ci.client_net().to_string(),
                             server_net: ci.server_net().to_string(),
                             service: name.clone(),

--- a/members/nullnet-server/ui/src/App.tsx
+++ b/members/nullnet-server/ui/src/App.tsx
@@ -8,6 +8,7 @@ import Pool from './pages/Pool';
 import Config from './pages/Config';
 import Events from './pages/Events';
 import Certificates from './pages/Certificates';
+import Topology from './pages/Topology';
 
 export default function App() {
   return (
@@ -22,6 +23,7 @@ export default function App() {
           <Route path="/config" element={<Config />} />
           <Route path="/certificates" element={<Certificates />} />
           <Route path="/events" element={<Events />} />
+          <Route path="/topology" element={<Topology />} />
         </Routes>
       </BrowserRouter>
     </StackProvider>

--- a/members/nullnet-server/ui/src/components/Layout.tsx
+++ b/members/nullnet-server/ui/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { useStack } from '../StackContext';
 import { useApi } from '../hooks/useApi';
 import type { SessionJson } from '../types';
 
-type Page = 'dashboard' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config' | 'certificates' | 'events';
+type Page = 'dashboard' | 'topology' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config' | 'certificates' | 'events';
 
 interface Props {
   page: Page;
@@ -16,7 +16,7 @@ const NAV = [
     group: 'Overview',
     items: [
       { id: 'dashboard', icon: '⊞', label: 'Dashboard', to: '/' },
-      { id: 'topology', icon: '⬡', label: 'Topology', to: null },
+      { id: 'topology', icon: '⬡', label: 'Topology', to: '/topology' },
     ],
   },
   {

--- a/members/nullnet-server/ui/src/components/topology/EdgePanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/EdgePanel.tsx
@@ -1,0 +1,43 @@
+import type { GraphEdgeJson } from '../../types';
+import { spRow, spKey, spCode } from './panelStyles';
+
+interface Props {
+  edge: GraphEdgeJson;
+}
+
+export default function EdgePanel({ edge }: Props) {
+  return (
+    <>
+      <div style={spRow}>
+        <div style={spKey}>Type</div>
+        <span className={`badge ${edge.via_proxy ? 'b-amber' : 'b-blue'}`}>
+          {edge.via_proxy ? 'Proxied' : 'Direct'}
+        </span>
+      </div>
+      <div style={spRow}>
+        <div style={spKey}>From</div>
+        <div style={spCode}>{edge.from}</div>
+      </div>
+      <div style={spRow}>
+        <div style={spKey}>To</div>
+        <div style={spCode}>{edge.to}</div>
+      </div>
+      {edge.via_proxy && (
+        <div style={spRow}>
+          <div style={spKey}>Via Proxy</div>
+          <div style={{ ...spCode, color: '#fbbf24' }}>{edge.via_proxy}</div>
+        </div>
+      )}
+      <div style={spRow}>
+        <div style={spKey}>Net ID</div>
+        <div style={spCode}>{edge.net_id}</div>
+      </div>
+      {edge.setup_ms > 0 && (
+        <div style={spRow}>
+          <div style={spKey}>Setup Time</div>
+          <div style={spCode}>{edge.setup_ms}ms</div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/InternetPanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/InternetPanel.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import type { SessionJson } from '../../types';
+import { spRow, spKey, SpSep } from './panelStyles';
+
+const PREVIEW_LIMIT = 5;
+
+function groupBySubnet(sessions: SessionJson[]) {
+  const map = new Map<string, SessionJson[]>();
+  for (const s of sessions) {
+    const prefix = s.client_ip.split('.').slice(0, 3).join('.');
+    if (!map.has(prefix)) map.set(prefix, []);
+    map.get(prefix)!.push(s);
+  }
+  return [...map.entries()]
+    .map(([prefix, group]) => ({
+      label: prefix + '.x',
+      sessions: group.sort((a, b) => b.created_at - a.created_at),
+    }))
+    .sort((a, b) => b.sessions.length - a.sessions.length);
+}
+
+function formatTime(unix: number): string {
+  return new Date(unix * 1000).toLocaleTimeString([], { hour12: false });
+}
+
+export default function InternetPanel({ sessions }: { sessions: SessionJson[] }) {
+  const [expanded, setExpanded] = useState(new Set<string>());
+
+  if (sessions.length === 0) {
+    return (
+      <div style={{ color: 'var(--t2)', fontSize: 11, textAlign: 'center', paddingTop: 24 }}>
+        No active clients
+      </div>
+    );
+  }
+
+  const groups = groupBySubnet(sessions);
+
+  return (
+    <>
+      <div style={spRow}>
+        <div style={spKey}>Summary</div>
+        <div style={{ fontSize: 12, color: 'var(--t0)', display: 'flex', gap: 8, alignItems: 'baseline' }}>
+          <span>
+            <span style={{ color: 'var(--cyan)', fontFamily: "'JetBrains Mono',monospace" }}>{sessions.length}</span>
+            {' '}client{sessions.length !== 1 ? 's' : ''}
+          </span>
+          <span style={{ color: 'var(--t3)' }}>·</span>
+          <span>
+            <span style={{ color: 'var(--blue)', fontFamily: "'JetBrains Mono',monospace" }}>{groups.length}</span>
+            {' '}subnet{groups.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+      </div>
+
+      <SpSep />
+
+      {groups.map(({ label, sessions: groupSessions }) => {
+        const isExpanded = expanded.has(label);
+        const shown = isExpanded ? groupSessions : groupSessions.slice(0, PREVIEW_LIMIT);
+        const hasMore = groupSessions.length > PREVIEW_LIMIT;
+
+        function toggleExpand() {
+          setExpanded(prev => {
+            const next = new Set(prev);
+            if (isExpanded) next.delete(label); else next.add(label);
+            return next;
+          });
+        }
+
+        return (
+          <div key={label} style={{ marginBottom: 14 }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 5 }}>
+              <span style={{ fontSize: 10, fontFamily: "'JetBrains Mono',monospace", color: 'var(--blue)', fontWeight: 600 }}>
+                ⬡ {label}
+              </span>
+              <span style={{ fontSize: 9.5, color: 'var(--t2)', fontFamily: "'JetBrains Mono',monospace" }}>
+                {groupSessions.length}
+              </span>
+            </div>
+
+            {shown.map(s => (
+              <div key={s.id} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', borderBottom: '1px solid rgba(255,255,255,.03)' }}>
+                <div style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--blue)', flexShrink: 0 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 11, fontFamily: "'JetBrains Mono',monospace", color: 'var(--t0)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
+                    {s.client_ip}
+                  </div>
+                  <div style={{ fontSize: 9.5, color: 'var(--t2)' }}>{s.service}</div>
+                </div>
+                <div style={{ flexShrink: 0, textAlign: 'right' as const }}>
+                  <div style={{ fontSize: 9.5, fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
+                    net {s.network_id}
+                  </div>
+                  <div style={{ fontSize: 9, color: 'var(--t2)' }}>{formatTime(s.created_at)}</div>
+                </div>
+              </div>
+            ))}
+
+            {hasMore && (
+              <button
+                onClick={toggleExpand}
+                style={{ display: 'block', width: '100%', padding: '5px 0', background: 'none', border: 'none', borderTop: '1px solid var(--t3)', color: 'var(--t2)', fontSize: 10, cursor: 'pointer', textAlign: 'left' as const, fontFamily: 'inherit' }}
+              >
+                {isExpanded ? 'Show less' : `+ ${groupSessions.length - PREVIEW_LIMIT} more`}
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/ProxyNodePanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/ProxyNodePanel.tsx
@@ -1,0 +1,45 @@
+import type { GraphEdgeJson } from '../../types';
+import { spRow, spKey, spVal, spCode } from './panelStyles';
+
+interface Props {
+  ip: string;
+  edges: GraphEdgeJson[];
+}
+
+export default function ProxyNodePanel({ ip, edges }: Props) {
+  const proxyEdges = edges.filter(e => e.via_proxy === ip);
+  const targets = [...new Set(proxyEdges.map(e => e.to))];
+
+  return (
+    <>
+      <div style={spRow}>
+        <div style={spKey}>Type</div>
+        <span className="badge b-amber">Proxy entry</span>
+      </div>
+      <div style={spRow}>
+        <div style={spKey}>IP Address</div>
+        <div style={spCode}>{ip}</div>
+      </div>
+      <div style={spRow}>
+        <div style={spKey}>Active Tunnels</div>
+        <div style={{ ...spVal, color: 'var(--cyan)' }}>{proxyEdges.length}</div>
+      </div>
+      {targets.length > 0 && (
+        <div style={spRow}>
+          <div style={spKey}>Routing to</div>
+          <div>
+            {targets.map(t => {
+              const e = proxyEdges.find(e2 => e2.to === t)!;
+              return (
+                <div key={t} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '5px 0', borderBottom: '1px solid var(--t3)' }}>
+                  <span style={{ fontSize: 11, flex: 1, color: 'var(--t0)' }}>{t}</span>
+                  <span className="badge b-blue" style={{ fontSize: '8.5px' }}>net {e.net_id}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/ServiceNodePanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/ServiceNodePanel.tsx
@@ -1,0 +1,91 @@
+import type { ServiceJson } from '../../types';
+import type { TopoServiceNode } from './types';
+import { spRow, spKey, spVal, spCode, SpSep, SpSection } from './panelStyles';
+
+interface Props {
+  node: TopoServiceNode;
+  service: ServiceJson | undefined;
+  onDepClick: (id: string) => void;
+}
+
+export default function ServiceNodePanel({ node, service, onDepClick }: Props) {
+  const totalSessions = service?.replicas.reduce((s, r) => s + r.active_sessions, 0) ?? 0;
+  const deps = service ? [...new Set(service.proxy_dependencies.flat())] : [];
+
+  return (
+    <>
+      <div style={spRow}>
+        <div style={spKey}>Status</div>
+        <div>
+          <span className={`badge ${node.registered ? 'b-green' : 'b-dim'}`}>
+            {node.registered ? 'Registered' : 'Unregistered'}
+          </span>
+          {node.entry_point && <span className="badge b-blue" style={{ marginLeft: 6 }}>Entry Point</span>}
+        </div>
+      </div>
+
+      <div style={spRow}>
+        <div style={spKey}>Active Sessions</div>
+        <div style={{ ...spVal, color: 'var(--cyan)' }}>{totalSessions}</div>
+      </div>
+
+      <div style={spRow}>
+        <div style={spKey}>Replicas</div>
+        <div style={spVal}>{node.active_replica_count} active / {node.replica_count} total</div>
+      </div>
+
+      {service?.timeout_secs != null && (
+        <div style={spRow}>
+          <div style={spKey}>Timeout</div>
+          <div style={spCode}>{service.timeout_secs}s</div>
+        </div>
+      )}
+
+      {service?.max_networks != null && (
+        <div style={spRow}>
+          <div style={spKey}>Max Networks</div>
+          <div style={spCode}>{service.max_networks}</div>
+        </div>
+      )}
+
+      {deps.length > 0 && (
+        <div style={spRow}>
+          <div style={spKey}>Dependencies</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 2 }}>
+            {deps.map(dep => (
+              <button key={dep} onClick={() => onDepClick(dep)} className="dep-tag" style={{ cursor: 'pointer' }}>
+                {dep}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {service && service.replicas.length > 0 && (
+        <>
+          <SpSep />
+          <SpSection>Replicas</SpSection>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                {['Host', 'Port', 'Sess'].map(h => (
+                  <th key={h} style={{ fontSize: 9, color: 'var(--t2)', padding: '3px 0', textAlign: 'left', borderBottom: '1px solid var(--t3)', letterSpacing: '.05em', fontWeight: 500, textTransform: 'uppercase' as const }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {service.replicas.map((r, i) => (
+                <tr key={i}>
+                  <td style={{ fontSize: 11, padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,.03)', color: 'var(--cyan)', fontFamily: "'JetBrains Mono',monospace", maxWidth: 100, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>{r.ip}</td>
+                  <td style={{ fontSize: 11, padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,.03)', color: 'var(--t1)', fontFamily: "'JetBrains Mono',monospace" }}>{r.port}</td>
+                  <td style={{ fontSize: 11, padding: '5px 0', borderBottom: '1px solid rgba(255,255,255,.03)', color: 'var(--t2)' }}>{r.active_sessions}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+
+    </>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
@@ -1,0 +1,172 @@
+import type { GraphJson } from '../../types';
+import { NODE_W, NODE_H, INET_W, INET_H, INTERNET_ID } from './types';
+import { buildTopoGraph, layoutNodes, svgDims, edgePath, inetEdgePath } from './layout';
+
+interface Props {
+  graph: GraphJson;
+  showRegistered: boolean;
+  showUnregistered: boolean;
+  selectedNodeId: string | null;
+  selectedEdgeIdx: number | null;
+  onNodeClick: (id: string) => void;
+  onEdgeClick: (originalIdx: number) => void;
+}
+
+export default function TopologyGraph({
+  graph,
+  showRegistered,
+  showUnregistered,
+  selectedNodeId,
+  selectedEdgeIdx,
+  onNodeClick,
+  onEdgeClick,
+}: Props) {
+  const { nodes: allNodes, edges: allEdges } = buildTopoGraph(graph);
+
+  const nodes = allNodes.filter(n => {
+    if (n.kind !== 'service') return true;
+    if (n.registered && !showRegistered) return false;
+    if (!n.registered && !showUnregistered) return false;
+    return true;
+  });
+  const visibleIds = new Set(nodes.map(n => n.id));
+  const edges = allEdges.filter(e => visibleIds.has(e.from) && visibleIds.has(e.to));
+
+  const pos = layoutNodes(nodes, edges);
+  const { w, h } = svgDims(pos, nodes);
+
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: '100%', display: 'block', fontFamily: "'Plus Jakarta Sans',sans-serif" }}
+    >
+      <defs>
+        <filter id="gT"><feGaussianBlur stdDeviation="2.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+        <marker id="arr" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L8,3 z" fill="rgba(255,255,255,.25)" />
+        </marker>
+        <marker id="arr-proxy" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L8,3 z" fill="rgba(251,191,36,.4)" />
+        </marker>
+        <marker id="arr-sel" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L8,3 z" fill="rgba(91,156,246,.8)" />
+        </marker>
+        <marker id="arr-inet" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L8,3 z" fill="rgba(91,156,246,.35)" />
+        </marker>
+      </defs>
+
+      {/* Internet → Proxy edges (non-clickable, rendered first) */}
+      {edges.filter(e => e.isInternetEdge).map((e, i) => {
+        const fp = pos.get(e.from);
+        const tp = pos.get(e.to);
+        if (!fp || !tp) return null;
+        return (
+          <path
+            key={`inet-${i}`}
+            d={inetEdgePath(fp, tp)}
+            fill="none"
+            stroke="rgba(91,156,246,.3)"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+            markerEnd="url(#arr-inet)"
+            pointerEvents="none"
+          />
+        );
+      })}
+
+      {/* Service / proxy edges */}
+      {edges.filter(e => !e.isInternetEdge).map((e, i) => {
+        const fp = pos.get(e.from);
+        const tp = pos.get(e.to);
+        if (!fp || !tp) return null;
+        const isSel = e.originalIdx === selectedEdgeIdx;
+        const stroke = isSel
+          ? 'rgba(91,156,246,.9)'
+          : e.isProxyHop ? 'rgba(251,191,36,.35)' : 'rgba(255,255,255,.18)';
+        const arrowId = isSel ? 'arr-sel' : e.isProxyHop ? 'arr-proxy' : 'arr';
+        const midX = (fp.x + tp.x) / 2 + NODE_W / 2;
+        const midY = (fp.y + tp.y) / 2 + NODE_H / 2;
+        return (
+          <g key={i} onClick={() => onEdgeClick(e.originalIdx)} style={{ cursor: 'pointer' }}>
+            <path d={edgePath(fp, tp)} fill="none" stroke="transparent" strokeWidth="14" />
+            <path
+              d={edgePath(fp, tp)} fill="none" stroke={stroke}
+              strokeWidth={isSel ? 2 : 1.5}
+              strokeDasharray={e.isProxyHop && !isSel ? '4 3' : undefined}
+              markerEnd={`url(#${arrowId})`}
+              pointerEvents="none"
+            />
+            {e.setup_ms > 0 && !isSel && (
+              <text x={midX} y={midY} textAnchor="middle" fill="rgba(255,255,255,.3)" fontSize="9" pointerEvents="none">
+                net {e.net_id} · {e.setup_ms}ms
+              </text>
+            )}
+          </g>
+        );
+      })}
+
+      {/* Nodes */}
+      {nodes.map(n => {
+        const p = pos.get(n.id);
+        if (!p) return null;
+        const isSel = n.id === selectedNodeId;
+
+        if (n.kind === 'internet') {
+          return (
+            <g key={INTERNET_ID} onClick={() => onNodeClick(INTERNET_ID)} style={{ cursor: 'pointer' }}>
+              {isSel && (
+                <rect x={p.x - 3} y={p.y - 3} width={INET_W + 6} height={INET_H + 6} rx="14"
+                  fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
+              )}
+              <rect x={p.x} y={p.y} width={INET_W} height={INET_H} rx="11"
+                fill="rgba(91,156,246,.05)" stroke="rgba(91,156,246,.2)"
+                strokeWidth="1" strokeDasharray="4 3" filter="url(#gT)" />
+              <text x={p.x + INET_W / 2} y={p.y + INET_H / 2 + 4}
+                textAnchor="middle" fill="rgba(91,156,246,.7)" fontSize="9.5" fontWeight="600" pointerEvents="none">
+                ⬡ internet
+              </text>
+            </g>
+          );
+        }
+
+        if (n.kind === 'proxy') {
+          return (
+            <g key={n.id} onClick={() => onNodeClick(n.id)} style={{ cursor: 'pointer' }}>
+              {isSel && (
+                <rect x={p.x - 3} y={p.y - 3} width={NODE_W + 6} height={NODE_H + 6} rx="10"
+                  fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
+              )}
+              <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
+                fill="rgba(251,191,36,.06)" stroke="rgba(251,191,36,.4)"
+                strokeWidth="1" strokeDasharray="5 3" filter="url(#gT)" />
+              <circle cx={p.x + 15} cy={p.y + 19} r="3.5" fill="#fbbf24" />
+              <text x={p.x + 27} y={p.y + 16} fill="rgba(251,191,36,.9)" fontSize="9.5" fontWeight="500" pointerEvents="none">proxy</text>
+              <text x={p.x + 27} y={p.y + 28} fill="rgba(255,255,255,.4)" fontSize="8" fontFamily="'JetBrains Mono',monospace" pointerEvents="none">{n.id}</text>
+            </g>
+          );
+        }
+
+        const color = n.registered ? '#34d399' : '#f87171';
+        const strokeColor = n.registered ? 'rgba(52,211,153,.3)' : 'rgba(248,113,113,.2)';
+        return (
+          <g key={n.id} onClick={() => onNodeClick(n.id)} style={{ cursor: 'pointer' }}>
+            {isSel && (
+              <rect x={p.x - 3} y={p.y - 3} width={NODE_W + 6} height={NODE_H + 6} rx="10"
+                fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
+            )}
+            <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
+              fill="rgba(255,255,255,.04)" stroke={strokeColor} strokeWidth="1" filter="url(#gT)" />
+            <circle cx={p.x + 15} cy={p.y + 19} r="3.5" fill={color} />
+            <text x={p.x + 27} y={p.y + 16} fill="rgba(255,255,255,.85)" fontSize="9.5" fontWeight="500" pointerEvents="none">{n.id}</text>
+            <text x={p.x + 27} y={p.y + 28} fill="rgba(255,255,255,.3)" fontSize="8" pointerEvents="none">
+              {n.registered ? `${n.active_replica_count}/${n.replica_count} active` : 'unregistered'}
+              {n.entry_point ? ' · entry' : ''}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/TopologyPanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyPanel.tsx
@@ -1,0 +1,85 @@
+import type { GraphJson, ServiceJson, SessionJson } from '../../types';
+import type { PanelState } from './types';
+import ServiceNodePanel from './ServiceNodePanel';
+import ProxyNodePanel from './ProxyNodePanel';
+import EdgePanel from './EdgePanel';
+import InternetPanel from './InternetPanel';
+
+interface Props {
+  panel: PanelState;
+  graph: GraphJson;
+  services: ServiceJson[] | null;
+  sessions: SessionJson[] | null;
+  onClose: () => void;
+  onNodeClick: (id: string) => void;
+}
+
+export default function TopologyPanel({ panel, graph, services, sessions, onClose, onNodeClick }: Props) {
+  function getTitle(): string {
+    if (!panel) return '–';
+    if (panel.type === 'internet') return 'Internet Clients';
+    if (panel.type === 'edge') {
+      const e = graph.edges[panel.edgeIdx];
+      return e ? `${e.from} → ${e.to}` : '–';
+    }
+    return panel.nodeId;
+  }
+
+  function renderContent() {
+    if (!panel) return null;
+
+    if (panel.type === 'internet') {
+      return <InternetPanel sessions={sessions ?? []} />;
+    }
+
+    if (panel.type === 'edge') {
+      const e = graph.edges[panel.edgeIdx];
+      return e ? <EdgePanel edge={e} /> : null;
+    }
+
+    const { nodeId } = panel;
+    const graphNode = graph.nodes.find(n => n.id === nodeId);
+    if (graphNode) {
+      return (
+        <ServiceNodePanel
+          node={{ ...graphNode, kind: 'service' }}
+          service={services?.find(s => s.name === nodeId)}
+          onDepClick={onNodeClick}
+        />
+      );
+    }
+    if (graph.edges.some(e => e.via_proxy === nodeId)) {
+      return <ProxyNodePanel ip={nodeId} edges={graph.edges} />;
+    }
+    return null;
+  }
+
+  return (
+    <div style={{
+      position: 'fixed', top: 48, right: 0, bottom: 0, width: 268,
+      background: 'rgba(3,5,8,.95)',
+      backdropFilter: 'blur(28px)', WebkitBackdropFilter: 'blur(28px)',
+      borderLeft: '1px solid var(--gb)',
+      display: 'flex', flexDirection: 'column',
+      transform: panel ? 'translateX(0)' : 'translateX(100%)',
+      transition: 'transform .22s cubic-bezier(.4,0,.2,1)',
+      zIndex: 50,
+    }}>
+      <div style={{ padding: '14px 18px', borderBottom: '1px solid var(--t3)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
+        <span style={{
+          fontSize: 13, fontWeight: 600, color: 'var(--t0)',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          maxWidth: 210, fontFamily: "'JetBrains Mono',monospace",
+        }}>
+          {getTitle()}
+        </span>
+        <button onClick={onClose} style={{ background: 'none', border: 'none', color: 'var(--t2)', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0, flexShrink: 0 }}>
+          ✕
+        </button>
+      </div>
+      <div style={{ padding: '16px 18px', overflowY: 'auto', flex: 1 }}>
+        {renderContent()}
+      </div>
+    </div>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/layout.ts
+++ b/members/nullnet-server/ui/src/components/topology/layout.ts
@@ -1,0 +1,134 @@
+import type { GraphJson } from '../../types';
+import { NODE_W, NODE_H, H_GAP, V_GAP, INET_W, INET_H, INET_Y, INET_PROXY_GAP, INTERNET_ID } from './types';
+import type { Pos, TopoNode, TopoEdge } from './types';
+
+export function buildTopoGraph(graph: GraphJson): { nodes: TopoNode[]; edges: TopoEdge[] } {
+  const nodes: TopoNode[] = graph.nodes.map(n => ({ ...n, kind: 'service' as const }));
+  const proxyIps = new Set<string>();
+  for (const e of graph.edges) { if (e.via_proxy) proxyIps.add(e.via_proxy); }
+  for (const ip of proxyIps) nodes.push({ kind: 'proxy', id: ip });
+
+  // Internet node — added whenever there are proxy nodes
+  if (proxyIps.size > 0) {
+    nodes.push({ kind: 'internet', id: INTERNET_ID });
+  }
+
+  const edges: TopoEdge[] = [];
+
+  // Internet → Proxy edges
+  for (const ip of proxyIps) {
+    edges.push({ from: INTERNET_ID, to: ip, net_id: -1, setup_ms: 0, isProxyHop: false, isInternetEdge: true, originalIdx: -1 });
+  }
+
+  for (let idx = 0; idx < graph.edges.length; idx++) {
+    const e = graph.edges[idx];
+    if (e.via_proxy) {
+      edges.push({ from: e.from, to: e.via_proxy, net_id: e.net_id, setup_ms: 0, isProxyHop: true, isInternetEdge: false, originalIdx: idx });
+      edges.push({ from: e.via_proxy, to: e.to, net_id: e.net_id, setup_ms: e.setup_ms, isProxyHop: true, isInternetEdge: false, originalIdx: idx });
+    } else {
+      edges.push({ from: e.from, to: e.to, net_id: e.net_id, setup_ms: e.setup_ms, isProxyHop: false, isInternetEdge: false, originalIdx: idx });
+    }
+  }
+  return { nodes, edges };
+}
+
+export function layoutNodes(nodes: TopoNode[], edges: TopoEdge[]): Map<string, Pos> {
+  const hasInternet = nodes.some(n => n.kind === 'internet');
+  const proxyNodes = nodes.filter(n => n.kind === 'proxy');
+  const serviceNodes = nodes.filter(n => n.kind === 'service');
+  const pos = new Map<string, Pos>();
+
+  // Proxy row y shifts down when internet node is present
+  const proxyRowY = hasInternet ? INET_Y + INET_H + INET_PROXY_GAP : V_GAP;
+
+  proxyNodes.forEach((n, i) => {
+    pos.set(n.id, { x: H_GAP + i * (NODE_W + H_GAP), y: proxyRowY });
+  });
+
+  // Internet node — centered over the proxy row
+  if (hasInternet && proxyNodes.length > 0) {
+    const proxyRowCenter = H_GAP + ((proxyNodes.length - 1) * (NODE_W + H_GAP)) / 2 + NODE_W / 2;
+    pos.set(INTERNET_ID, { x: proxyRowCenter - INET_W / 2, y: INET_Y });
+  }
+
+  const svcOffsetY = proxyNodes.length > 0 ? proxyRowY + NODE_H + V_GAP : V_GAP;
+  const svcSet = new Set(serviceNodes.map(n => n.id));
+  const out = new Map<string, Set<string>>();
+  const inc = new Map<string, Set<string>>();
+  for (const n of serviceNodes) { out.set(n.id, new Set()); inc.set(n.id, new Set()); }
+  for (const e of edges) {
+    if (svcSet.has(e.from) && svcSet.has(e.to)) {
+      out.get(e.from)!.add(e.to);
+      inc.get(e.to)!.add(e.from);
+    }
+  }
+
+  const layer = new Map<string, number>();
+  const q: string[] = serviceNodes.filter(n => !inc.get(n.id)?.size).map(n => n.id);
+  q.forEach(id => layer.set(id, 0));
+  for (let i = 0; i < q.length; i++) {
+    const id = q[i], l = layer.get(id)!;
+    for (const next of out.get(id) ?? []) {
+      layer.set(next, Math.max(layer.get(next) ?? 0, l + 1));
+      q.push(next);
+    }
+  }
+  for (const n of serviceNodes) { if (!layer.has(n.id)) layer.set(n.id, 0); }
+
+  const byLayer = new Map<number, string[]>();
+  for (const [id, l] of layer) {
+    if (!byLayer.has(l)) byLayer.set(l, []);
+    byLayer.get(l)!.push(id);
+  }
+  for (const l of [...byLayer.keys()].sort((a, b) => a - b)) {
+    const row = byLayer.get(l)!.sort();
+    row.forEach((id, i) => pos.set(id, { x: H_GAP + i * (NODE_W + H_GAP), y: svcOffsetY + l * (NODE_H + V_GAP) }));
+  }
+  return pos;
+}
+
+export function svgDims(pos: Map<string, Pos>, nodes: TopoNode[]): { w: number; h: number } {
+  const nodeById = new Map(nodes.map(n => [n.id, n]));
+  let maxX = 0, maxY = 0;
+  for (const [id, { x, y }] of pos.entries()) {
+    const n = nodeById.get(id);
+    const nw = n?.kind === 'internet' ? INET_W : NODE_W;
+    const nh = n?.kind === 'internet' ? INET_H : NODE_H;
+    maxX = Math.max(maxX, x + nw);
+    maxY = Math.max(maxY, y + nh);
+  }
+  return { w: maxX + H_GAP, h: maxY + V_GAP };
+}
+
+export function edgePath(from: Pos, to: Pos): string {
+  const fromMidY = from.y + NODE_H / 2;
+  const toMidY = to.y + NODE_H / 2;
+  if (toMidY > fromMidY + NODE_H) {
+    const x1 = from.x + NODE_W / 2, y1 = from.y + NODE_H;
+    const x2 = to.x + NODE_W / 2, y2 = to.y;
+    const cy = (y1 + y2) / 2;
+    return `M ${x1} ${y1} C ${x1} ${cy}, ${x2} ${cy}, ${x2} ${y2}`;
+  }
+  if (fromMidY > toMidY + NODE_H) {
+    const x1 = from.x + NODE_W / 2, y1 = from.y;
+    const x2 = to.x + NODE_W / 2, y2 = to.y + NODE_H;
+    const cy = (y1 + y2) / 2;
+    return `M ${x1} ${y1} C ${x1} ${cy}, ${x2} ${cy}, ${x2} ${y2}`;
+  }
+  const goRight = to.x >= from.x;
+  const x1 = goRight ? from.x + NODE_W : from.x;
+  const y1 = from.y + NODE_H / 2;
+  const x2 = goRight ? to.x : to.x + NODE_W;
+  const y2 = to.y + NODE_H / 2;
+  const cx = (x1 + x2) / 2;
+  return `M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}`;
+}
+
+export function inetEdgePath(from: Pos, to: Pos): string {
+  const x1 = from.x + INET_W / 2;
+  const y1 = from.y + INET_H;
+  const x2 = to.x + NODE_W / 2;
+  const y2 = to.y;
+  const cy = (y1 + y2) / 2;
+  return `M ${x1} ${y1} C ${x1} ${cy}, ${x2} ${cy}, ${x2} ${y2}`;
+}

--- a/members/nullnet-server/ui/src/components/topology/panelStyles.tsx
+++ b/members/nullnet-server/ui/src/components/topology/panelStyles.tsx
@@ -1,0 +1,15 @@
+export const spRow = { marginBottom: 12 };
+export const spKey = { fontSize: 10, color: 'var(--t2)', marginBottom: 3, letterSpacing: '.04em', fontWeight: 500 };
+export const spVal = { fontSize: 12, color: 'var(--t0)' };
+export const spCode = { fontSize: 11, color: 'var(--cyan)', fontFamily: "'JetBrains Mono',monospace" };
+export function SpSep() {
+  return <hr style={{ border: 'none', borderTop: '1px solid var(--t3)', margin: '12px 0' }} />;
+}
+
+export function SpSection({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--t2)', letterSpacing: '.04em', marginBottom: 8 }}>
+      {children}
+    </div>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/types.ts
+++ b/members/nullnet-server/ui/src/components/topology/types.ts
@@ -1,0 +1,36 @@
+import type { GraphNodeJson } from '../../types';
+
+export const NODE_W = 130;
+export const NODE_H = 38;
+export const H_GAP = 60;
+export const V_GAP = 70;
+
+export const INET_W = 140;
+export const INET_H = 22;
+export const INET_Y = 35;          // top y of internet node
+export const INET_PROXY_GAP = 50;  // gap between internet bottom and proxy top
+
+export const INTERNET_ID = 'internet';
+
+export interface Pos { x: number; y: number }
+
+export type PanelState =
+  | null
+  | { type: 'node'; nodeId: string }
+  | { type: 'edge'; edgeIdx: number }
+  | { type: 'internet' };
+
+export interface TopoServiceNode extends GraphNodeJson { kind: 'service' }
+export interface TopoProxyNode { kind: 'proxy'; id: string }
+export interface TopoInternetNode { kind: 'internet'; id: string }
+export type TopoNode = TopoServiceNode | TopoProxyNode | TopoInternetNode;
+
+export interface TopoEdge {
+  from: string;
+  to: string;
+  net_id: number;
+  setup_ms: number;
+  isProxyHop: boolean;
+  isInternetEdge: boolean;
+  originalIdx: number;
+}

--- a/members/nullnet-server/ui/src/pages/Dashboard.tsx
+++ b/members/nullnet-server/ui/src/pages/Dashboard.tsx
@@ -1,7 +1,9 @@
 import Layout from '../components/Layout';
 import { useApi } from '../hooks/useApi';
 import { useStack } from '../StackContext';
-import type { SessionJson, ServiceJson, NodeJson, PoolJson } from '../types';
+import type { SessionJson, ServiceJson, NodeJson, PoolJson, GraphJson } from '../types';
+import { buildTopoGraph, layoutNodes, svgDims, edgePath, inetEdgePath } from '../components/topology/layout';
+import { NODE_W, NODE_H, INET_W, INET_H, INTERNET_ID } from '../components/topology/types';
 
 export default function Dashboard() {
   const { stack } = useStack();
@@ -9,6 +11,7 @@ export default function Dashboard() {
   const { data: services } = useApi<ServiceJson[]>(`/api/services/${stack}`, 5000);
   const { data: nodes } = useApi<NodeJson[]>('/api/nodes', 5000);
   const { data: pool } = useApi<PoolJson>('/api/pool', 5000);
+  const { data: graph } = useApi<GraphJson>(`/api/graph/${stack}`, 5000);
 
   const totalSvc = services?.length ?? 0;
   const onlineSvc = services?.filter(s => s.registered).length ?? 0;
@@ -58,36 +61,98 @@ export default function Dashboard() {
           <div className="card glass">
             <div className="card-head">
               <span className="card-label">Topology</span>
-              <span style={{ fontSize: 10, color: 'var(--t2)' }}>live graph coming soon</span>
+              <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span className="live-dot" />live · 5s
+              </span>
             </div>
             <div style={{ background: 'rgba(0,0,0,.25)', padding: 12 }}>
-              <svg viewBox="0 0 700 280" xmlns="http://www.w3.org/2000/svg" style={{ width: '100%', display: 'block', fontFamily: "'Plus Jakarta Sans',sans-serif" }}>
-                <defs>
-                  <filter id="gA"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-                  <filter id="gT"><feGaussianBlur stdDeviation="2.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-                </defs>
-                {services?.map((svc, i) => {
-                  const total = Math.max(services.length, 1);
-                  const x = 100 + (i / (total - 1 || 1)) * 500;
-                  const y = i % 2 === 0 ? 80 : 160;
-                  const color = svc.registered ? '#34d399' : '#f87171';
-                  const strokeColor = svc.registered ? 'rgba(52,211,153,.3)' : 'rgba(248,113,113,.2)';
-                  return (
-                    <g key={svc.name}>
-                      <rect x={x - 65} y={y - 20} width={130} height={38} rx="8"
-                        fill="rgba(255,255,255,.04)" stroke={strokeColor} strokeWidth="1" filter="url(#gT)" />
-                      <circle cx={x - 50} cy={y} r="3.5" fill={color} />
-                      <text x={x - 38} y={y - 4} fill="rgba(255,255,255,.85)" fontSize="9.5" fontWeight="500">{svc.name}</text>
-                      <text x={x - 38} y={y + 8} fill="rgba(255,255,255,.3)" fontSize="8">
-                        {svc.registered ? `${svc.replicas.length} replica${svc.replicas.length !== 1 ? 's' : ''}` : 'unregistered'}
-                      </text>
-                    </g>
-                  );
-                })}
-                {!services && (
-                  <text x="350" y="140" textAnchor="middle" fill="rgba(255,255,255,.2)" fontSize="11">loading topology…</text>
-                )}
-              </svg>
+              {!graph && (
+                <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>loading topology…</div>
+              )}
+              {graph && (() => {
+                const { nodes: topoNodes, edges: topoEdges } = buildTopoGraph(graph);
+                const pos = layoutNodes(topoNodes, topoEdges);
+                const { w, h } = svgDims(pos, topoNodes);
+                return (
+                  <svg viewBox={`0 0 ${w} ${h}`} xmlns="http://www.w3.org/2000/svg" style={{ width: '100%', display: 'block', fontFamily: "'Plus Jakarta Sans',sans-serif" }}>
+                    <defs>
+                      <filter id="db-gT"><feGaussianBlur stdDeviation="2.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+                      <marker id="db-arr" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                        <path d="M0,0 L0,6 L6,3 z" fill="rgba(255,255,255,.2)" />
+                      </marker>
+                      <marker id="db-arr-proxy" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                        <path d="M0,0 L0,6 L6,3 z" fill="rgba(251,191,36,.35)" />
+                      </marker>
+                      <marker id="db-arr-inet" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                        <path d="M0,0 L0,6 L6,3 z" fill="rgba(91,156,246,.35)" />
+                      </marker>
+                    </defs>
+
+                    {/* Internet → proxy edges */}
+                    {topoEdges.filter(e => e.isInternetEdge).map((e, i) => {
+                      const fp = pos.get(e.from); const tp = pos.get(e.to);
+                      if (!fp || !tp) return null;
+                      return <path key={`ie-${i}`} d={inetEdgePath(fp, tp)} fill="none" stroke="rgba(91,156,246,.3)" strokeWidth="1" strokeDasharray="4 3" markerEnd="url(#db-arr-inet)" pointerEvents="none" />;
+                    })}
+
+                    {/* Service / proxy edges */}
+                    {topoEdges.filter(e => !e.isInternetEdge).map((e, i) => {
+                      const fp = pos.get(e.from); const tp = pos.get(e.to);
+                      if (!fp || !tp) return null;
+                      return <path key={i} d={edgePath(fp, tp)} fill="none"
+                        stroke={e.isProxyHop ? 'rgba(251,191,36,.3)' : 'rgba(255,255,255,.15)'}
+                        strokeWidth="1"
+                        strokeDasharray={e.isProxyHop ? '4 3' : undefined}
+                        markerEnd={e.isProxyHop ? 'url(#db-arr-proxy)' : 'url(#db-arr)'}
+                        pointerEvents="none" />;
+                    })}
+
+                    {/* Nodes */}
+                    {topoNodes.map(n => {
+                      const p = pos.get(n.id);
+                      if (!p) return null;
+
+                      if (n.kind === 'internet') return (
+                        <g key={INTERNET_ID}>
+                          <rect x={p.x} y={p.y} width={INET_W} height={INET_H} rx="11"
+                            fill="rgba(91,156,246,.05)" stroke="rgba(91,156,246,.2)"
+                            strokeWidth="1" strokeDasharray="4 3" filter="url(#db-gT)" />
+                          <text x={p.x + INET_W / 2} y={p.y + INET_H / 2 + 4}
+                            textAnchor="middle" fill="rgba(91,156,246,.7)" fontSize="9.5" fontWeight="600" pointerEvents="none">
+                            ⬡ internet
+                          </text>
+                        </g>
+                      );
+
+                      if (n.kind === 'proxy') return (
+                        <g key={n.id}>
+                          <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
+                            fill="rgba(251,191,36,.06)" stroke="rgba(251,191,36,.4)"
+                            strokeWidth="1" strokeDasharray="5 3" filter="url(#db-gT)" />
+                          <circle cx={p.x + 15} cy={p.y + 19} r="3.5" fill="#fbbf24" />
+                          <text x={p.x + 27} y={p.y + 16} fill="rgba(251,191,36,.9)" fontSize="9.5" fontWeight="500" pointerEvents="none">proxy</text>
+                          <text x={p.x + 27} y={p.y + 28} fill="rgba(255,255,255,.4)" fontSize="8" fontFamily="'JetBrains Mono',monospace" pointerEvents="none">{n.id}</text>
+                        </g>
+                      );
+
+                      const color = n.registered ? '#34d399' : '#f87171';
+                      const strokeColor = n.registered ? 'rgba(52,211,153,.3)' : 'rgba(248,113,113,.2)';
+                      return (
+                        <g key={n.id}>
+                          <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
+                            fill="rgba(255,255,255,.04)" stroke={strokeColor} strokeWidth="1" filter="url(#db-gT)" />
+                          <circle cx={p.x + 15} cy={p.y + 19} r="3.5" fill={color} />
+                          <text x={p.x + 27} y={p.y + 16} fill="rgba(255,255,255,.85)" fontSize="9.5" fontWeight="500" pointerEvents="none">{n.id}</text>
+                          <text x={p.x + 27} y={p.y + 28} fill="rgba(255,255,255,.3)" fontSize="8" pointerEvents="none">
+                            {n.registered ? `${n.active_replica_count}/${n.replica_count} active` : 'unregistered'}
+                            {n.entry_point ? ' · entry' : ''}
+                          </text>
+                        </g>
+                      );
+                    })}
+                  </svg>
+                );
+              })()}
             </div>
           </div>
 

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import Layout from '../components/Layout';
 import type { EventJson, Severity } from '../types';
 
@@ -158,9 +159,27 @@ const MAX_EVENTS = 500;
 const SEVERITIES: Severity[] = ['info', 'warning', 'error'];
 
 export default function Events() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const kindFilter = searchParams.get('kind') ?? '';
+  const severityFilter = (searchParams.get('severity') ?? '') as Severity | '';
+
+  function setKindFilter(kind: string) {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      if (kind) next.set('kind', kind); else next.delete('kind');
+      return next;
+    }, { replace: true });
+  }
+
+  function setSeverityFilter(s: Severity | '') {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      if (s) next.set('severity', s); else next.delete('severity');
+      return next;
+    }, { replace: true });
+  }
+
   const [events, setEvents] = useState<EventJson[]>([]);
-  const [kindFilter, setKindFilter] = useState<string>('');
-  const [severityFilter, setSeverityFilter] = useState<Severity | ''>('');
   const [paused, setPaused] = useState(false);
   const [liveCount, setLiveCount] = useState(0);
   const pausedRef = useRef(paused);
@@ -234,7 +253,7 @@ export default function Events() {
                 <button
                   key={s}
                   style={chipStyle(severityFilter === s, SEVERITY_COLOR[s])}
-                  onClick={() => setSeverityFilter(prev => prev === s ? '' : s)}
+                  onClick={() => setSeverityFilter(severityFilter === s ? '' : s)}
                 >
                   {s.charAt(0).toUpperCase() + s.slice(1)}
                 </button>

--- a/members/nullnet-server/ui/src/pages/Topology.tsx
+++ b/members/nullnet-server/ui/src/pages/Topology.tsx
@@ -1,0 +1,204 @@
+import { useState, useEffect, useRef } from 'react';
+import Layout from '../components/Layout';
+import { useApi } from '../hooks/useApi';
+import { useStack } from '../StackContext';
+import type { GraphJson, ServiceJson, SessionJson } from '../types';
+import type { PanelState } from '../components/topology/types';
+import { INTERNET_ID } from '../components/topology/types';
+import TopologyGraph from '../components/topology/TopologyGraph';
+import TopologyPanel from '../components/topology/TopologyPanel';
+
+export default function Topology() {
+  const { stack } = useStack();
+  const { data: graph, refetch } = useApi<GraphJson>(`/api/graph/${stack}`);
+  const { data: services } = useApi<ServiceJson[]>(`/api/services/${stack}`, 5000);
+  const { data: sessions } = useApi<SessionJson[]>('/api/sessions', 5000);
+
+  const [panel, setPanel] = useState<PanelState>(null);
+  const [showRegistered, setShowRegistered] = useState(true);
+  const [showUnregistered, setShowUnregistered] = useState(true);
+
+  useEffect(() => { setPanel(null); }, [stack]);
+
+  const refetchRef = useRef(refetch);
+  refetchRef.current = refetch;
+  useEffect(() => {
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (ev) => {
+      try {
+        const event = JSON.parse(ev.data);
+        if (event.type === 'session_created' || event.type === 'session_torn_down') refetchRef.current();
+      } catch { /* ignore */ }
+    };
+    return () => es.close();
+  }, []);
+
+  const nodeCount = graph?.nodes.length ?? 0;
+  const registeredCount = graph?.nodes.filter(n => n.registered).length ?? 0;
+  const edgeCount = graph?.edges.length ?? 0;
+  const proxyCount = graph
+    ? new Set(graph.edges.filter(e => e.via_proxy).map(e => e.via_proxy!)).size
+    : 0;
+
+  const selectedNodeId =
+    panel?.type === 'node' ? panel.nodeId :
+    panel?.type === 'internet' ? INTERNET_ID :
+    null;
+  const selectedEdgeIdx = panel?.type === 'edge' ? panel.edgeIdx : null;
+
+  function handleNodeClick(nodeId: string) {
+    if (nodeId === INTERNET_ID) {
+      setPanel(p => p?.type === 'internet' ? null : { type: 'internet' });
+      return;
+    }
+    setPanel(p => p?.type === 'node' && p.nodeId === nodeId ? null : { type: 'node', nodeId });
+  }
+  function handleEdgeClick(edgeIdx: number) {
+    setPanel(p => p?.type === 'edge' && p.edgeIdx === edgeIdx ? null : { type: 'edge', edgeIdx });
+  }
+
+  return (
+    <Layout
+      page="topology"
+      topbarRight={
+        <span style={{ fontSize: 11, color: 'var(--t1)', display: 'flex', alignItems: 'center', gap: 5 }}>
+          <span className="live-dot" />live · SSE
+        </span>
+      }
+    >
+      <div className="content">
+        <div className="stats">
+          <div className="stat glass">
+            <div className="stat-label">Services</div>
+            <div className="stat-value">{registeredCount}<span className="denom">/{nodeCount}</span></div>
+            <div className="stat-sub">{nodeCount - registeredCount} unregistered</div>
+          </div>
+          <div className="stat glass">
+            <div className="stat-label">Active Edges</div>
+            <div className="stat-value" style={{ color: 'var(--cyan)' }}>{edgeCount}</div>
+            <div className="stat-sub">live connections</div>
+          </div>
+
+          <div className="stat glass">
+            <div className="stat-label">Entry Points</div>
+            <div className="stat-value" style={{ color: 'var(--green)' }}>
+              {graph?.nodes.filter(n => n.entry_point).length ?? '—'}
+            </div>
+            <div className="stat-sub">with timeout</div>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 2px', flexWrap: 'wrap' as const }}>
+          <span style={{ fontSize: 10, color: 'var(--t2)', letterSpacing: '.08em' }}>FILTER</span>
+          <button className={`filter-chip${showRegistered ? ' on' : ''}`} onClick={() => setShowRegistered(p => !p)}>
+            Registered
+          </button>
+          <button className={`filter-chip${showUnregistered ? ' on' : ''}`} onClick={() => setShowUnregistered(p => !p)}>
+            Unregistered
+          </button>
+          <span style={{ width: 1, height: 18, background: 'var(--t3)', margin: '0 2px', display: 'inline-block' }} />
+          <span style={{ fontSize: 11, color: 'var(--t2)' }}>Click node or edge to inspect</span>
+        </div>
+
+        <div className="card glass">
+          <div className="card-head">
+            <span className="card-label">Service Topology</span>
+            <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', gap: 10 }}>
+              {graph ? (
+                <>
+                  <span>{nodeCount} services</span>
+                  {proxyCount > 0 && <span style={{ color: '#fbbf24' }}>{proxyCount} prox{proxyCount === 1 ? 'y' : 'ies'}</span>}
+                  <span>{edgeCount} edges</span>
+                </>
+              ) : 'loading…'}
+            </span>
+          </div>
+          <div style={{ background: 'rgba(0,0,0,.25)', padding: 16, minHeight: 200 }}>
+            {!graph && (
+              <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
+                loading topology…
+              </div>
+            )}
+            {graph && graph.nodes.length === 0 && (
+              <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
+                No services registered for stack <b>{stack}</b>
+              </div>
+            )}
+            {graph && graph.nodes.length > 0 && (
+              <TopologyGraph
+                graph={graph}
+                showRegistered={showRegistered}
+                showUnregistered={showUnregistered}
+                selectedNodeId={selectedNodeId}
+                selectedEdgeIdx={selectedEdgeIdx}
+                onNodeClick={handleNodeClick}
+                onEdgeClick={handleEdgeClick}
+              />
+            )}
+          </div>
+          {proxyCount > 0 && (
+            <div style={{ padding: '8px 14px 10px', display: 'flex', gap: 16, fontSize: 10, color: 'var(--t2)', borderTop: '1px solid var(--gb)' }}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ width: 20, height: 1.5, background: 'rgba(255,255,255,.25)', display: 'inline-block' }} />
+                direct
+              </span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ width: 20, height: 1.5, display: 'inline-block', backgroundImage: 'repeating-linear-gradient(90deg, rgba(251,191,36,.45) 0, rgba(251,191,36,.45) 4px, transparent 4px, transparent 7px)' }} />
+                via proxy
+              </span>
+            </div>
+          )}
+        </div>
+
+        {graph && graph.edges.length > 0 && (
+          <div className="card glass" style={{ marginTop: 12 }}>
+            <div className="card-head">
+              <span className="card-label">Active Connections</span>
+            </div>
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>From</th>
+                  <th>Via Proxy</th>
+                  <th>To</th>
+                  <th>Net ID</th>
+                  <th>Setup</th>
+                </tr>
+              </thead>
+              <tbody>
+                {graph.edges.map((e, i) => (
+                  <tr
+                    key={i}
+                    onClick={() => handleEdgeClick(i)}
+                    style={{ cursor: 'pointer', background: selectedEdgeIdx === i ? 'rgba(91,156,246,.07)' : undefined }}
+                  >
+                    <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.from}</td>
+                    <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: '#fbbf24' }}>
+                      {e.via_proxy ?? <span style={{ color: 'var(--t3)' }}>—</span>}
+                    </td>
+                    <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.to}</td>
+                    <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>{e.net_id}</td>
+                    <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
+                      {e.setup_ms > 0 ? `${e.setup_ms}ms` : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {graph && (
+        <TopologyPanel
+          panel={panel}
+          graph={graph}
+          services={services ?? null}
+          sessions={sessions ?? null}
+          onClose={() => setPanel(null)}
+          onNodeClick={handleNodeClick}
+        />
+      )}
+    </Layout>
+  );
+}

--- a/members/nullnet-server/ui/src/types.ts
+++ b/members/nullnet-server/ui/src/types.ts
@@ -107,3 +107,24 @@ export type EventJson =
   | WithSeverity & { type: 'certificate_installed'; domain: string }
   | WithSeverity & { type: 'certificate_renewed'; domain: string }
   | WithSeverity & { type: 'certificate_removed'; domain: string };
+
+export interface GraphNodeJson {
+  id: string;
+  registered: boolean;
+  entry_point: boolean;
+  replica_count: number;
+  active_replica_count: number;
+}
+
+export interface GraphEdgeJson {
+  from: string;
+  via_proxy?: string;
+  to: string;
+  net_id: number;
+  setup_ms: number;
+}
+
+export interface GraphJson {
+  nodes: GraphNodeJson[];
+  edges: GraphEdgeJson[];
+}


### PR DESCRIPTION
- Topology page with SVG graph: service nodes, proxy nodes, internet node (synthesized), layered BFS layout
- Clickable nodes and edges open a 268px slide-in side panel with per-node and per-edge details
- Internet node aggregates active sessions grouped by /24 subnet with collapsible preview rows
- SSE via EventSource refetches graph on session_created/torn_down
- Events page filters (type, severity, stack) persisted in URL params
- Dashboard topology mini-graph: proxy nodes, edges with correct arrow routing, internet node
- Fix sessions API client_ip returning proxy IP instead of real client IP