### PR TITLE
UI Enhancements — Topology Zoom & Stack Selector

### DIFF
--- a/members/nullnet-server/src/http_server/mod.rs
+++ b/members/nullnet-server/src/http_server/mod.rs
@@ -17,6 +17,7 @@ mod nodes;
 mod pool;
 mod services;
 mod sessions;
+mod stacks;
 mod static_files;
 
 const HTTP_PORT: u16 = 8080;
@@ -31,6 +32,7 @@ pub(crate) struct AppState {
 pub async fn serve(state: AppState) {
     let app = Router::new()
         .route("/api/health", get(health::health))
+        .route("/api/stacks", get(stacks::stacks_handler))
         .route("/api/services/{stack}", get(services::services_handler))
         .route("/api/nodes", get(nodes::nodes_handler))
         .route("/api/pool", get(pool::pool_handler))

--- a/members/nullnet-server/src/http_server/stacks.rs
+++ b/members/nullnet-server/src/http_server/stacks.rs
@@ -1,0 +1,10 @@
+use super::AppState;
+use axum::extract::State;
+use axum::response::IntoResponse;
+
+pub(super) async fn stacks_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let services = state.services.read().await;
+    let mut stacks: Vec<String> = services.keys().cloned().collect();
+    stacks.sort();
+    axum::Json(stacks)
+}

--- a/members/nullnet-server/ui/src/components/Layout.tsx
+++ b/members/nullnet-server/ui/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { NavLink } from 'react-router-dom';
 import { useStack } from '../StackContext';
 import { useApi } from '../hooks/useApi';
 import type { SessionJson } from '../types';
+import { useRef, useState, useEffect } from 'react';
 
 type Page = 'dashboard' | 'topology' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config' | 'certificates' | 'events';
 
@@ -41,6 +42,20 @@ const NAV = [
 export default function Layout({ page, topbarRight, children }: Props) {
   const { stack, setStack, editing, setEditing } = useStack();
   const { data: sessions } = useApi<SessionJson[]>('/api/sessions', 5000);
+  const { data: availableStacks } = useApi<string[]>('/api/stacks', 10000);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function onClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [dropdownOpen]);
 
   const sessionCount = sessions?.length ?? null;
 
@@ -86,7 +101,7 @@ export default function Layout({ page, topbarRight, children }: Props) {
 
         <div className="foot">
           <div className="foot-row"><span className="dot dot-g"></span>HTTP · 8080</div>
-          <div className="foot-stack">
+          <div className="foot-stack" ref={dropdownRef} style={{ position: 'relative' }}>
             <span>stack:</span>
             {editing ? (
               <input
@@ -99,7 +114,65 @@ export default function Layout({ page, topbarRight, children }: Props) {
                 }}
               />
             ) : (
-              <span className="foot-stack-name" title="Click to change stack" style={{ cursor: 'pointer' }} onClick={() => setEditing(true)}>{stack}</span>
+              <span
+                className="foot-stack-name"
+                title="Click to select or type a stack"
+                style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 3 }}
+                onClick={() => setDropdownOpen(o => !o)}
+                onDoubleClick={() => { setDropdownOpen(false); setEditing(true); }}
+              >
+                {stack}
+                <span style={{ fontSize: 8, color: 'var(--t3)', lineHeight: 1 }}>▾</span>
+              </span>
+            )}
+            {dropdownOpen && availableStacks && availableStacks.length > 0 && (
+              <div style={{
+                position: 'absolute',
+                bottom: '100%',
+                left: 0,
+                marginBottom: 4,
+                background: 'var(--surface, #1a1d24)',
+                border: '1px solid rgba(255,255,255,.12)',
+                borderRadius: 6,
+                padding: '4px 0',
+                minWidth: 140,
+                zIndex: 100,
+                boxShadow: '0 4px 16px rgba(0,0,0,.5)',
+              }}>
+                {availableStacks.map(s => (
+                  <div
+                    key={s}
+                    onClick={() => { setStack(s); setDropdownOpen(false); }}
+                    style={{
+                      padding: '5px 12px',
+                      fontSize: 11,
+                      cursor: 'pointer',
+                      color: s === stack ? 'var(--accent, #5b9cf6)' : 'rgba(255,255,255,.75)',
+                      background: s === stack ? 'rgba(91,156,246,.08)' : 'transparent',
+                      fontFamily: "'JetBrains Mono', monospace",
+                    }}
+                    onMouseEnter={e => { if (s !== stack) (e.target as HTMLElement).style.background = 'rgba(255,255,255,.05)'; }}
+                    onMouseLeave={e => { (e.target as HTMLElement).style.background = s === stack ? 'rgba(91,156,246,.08)' : 'transparent'; }}
+                  >
+                    {s}
+                  </div>
+                ))}
+                <div
+                  style={{
+                    padding: '5px 12px',
+                    fontSize: 10,
+                    cursor: 'pointer',
+                    color: 'var(--t3)',
+                    borderTop: '1px solid rgba(255,255,255,.06)',
+                    marginTop: 2,
+                  }}
+                  onClick={() => { setDropdownOpen(false); setEditing(true); }}
+                  onMouseEnter={e => { (e.target as HTMLElement).style.color = 'rgba(255,255,255,.5)'; }}
+                  onMouseLeave={e => { (e.target as HTMLElement).style.color = 'var(--t3)'; }}
+                >
+                  type custom…
+                </div>
+              </div>
             )}
           </div>
         </div>

--- a/members/nullnet-server/ui/src/components/topology/TopologyContext.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyContext.tsx
@@ -22,8 +22,6 @@ const TopologyDataContext = createContext<TopologyData>({
 
 interface UIState {
   panel: PanelState;
-  showRegistered: boolean;
-  showUnregistered: boolean;
   focusedClientIp: string | null;
 }
 
@@ -31,15 +29,11 @@ export type UIAction =
   | { type: 'NODE_CLICKED'; nodeId: string }
   | { type: 'EDGE_CLICKED'; fromId: string; toId: string; edgeIndices: number[] }
   | { type: 'PANEL_CLOSED' }
-  | { type: 'REGISTERED_TOGGLED' }
-  | { type: 'UNREGISTERED_TOGGLED' }
   | { type: 'CLIENT_FOCUSED'; ip: string }
   | { type: 'STACK_CHANGED' };
 
 const initialUIState: UIState = {
   panel: null,
-  showRegistered: true,
-  showUnregistered: true,
   focusedClientIp: null,
 };
 
@@ -72,10 +66,6 @@ function uiReducer(state: UIState, action: UIAction): UIState {
       };
     case 'PANEL_CLOSED':
       return { ...state, panel: null };
-    case 'REGISTERED_TOGGLED':
-      return { ...state, showRegistered: !state.showRegistered };
-    case 'UNREGISTERED_TOGGLED':
-      return { ...state, showUnregistered: !state.showUnregistered };
     case 'CLIENT_FOCUSED':
       return {
         ...state,
@@ -96,6 +86,7 @@ interface TopologyUI extends UIState {
   nodeIps: Map<string, string>;
   dispatch: React.Dispatch<UIAction>;
 }
+
 
 const TopologyUIContext = createContext<TopologyUI>({
   ...initialUIState,

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
@@ -1,5 +1,6 @@
 import { useTopologyData, useTopologyUI } from './TopologyContext';
 import TopologyGraphSvg from './TopologyGraphSvg';
+import ZoomFrame from './ZoomFrame';
 
 export default function TopologyGraph() {
   const { graph } = useTopologyData();
@@ -17,19 +18,21 @@ export default function TopologyGraph() {
   if (!graph) return null;
 
   return (
-    <TopologyGraphSvg
-      graph={graph}
-      showRegistered={showRegistered}
-      showUnregistered={showUnregistered}
-      selectedNodeId={selectedNodeId}
-      selectedEdgeKey={selectedEdgeKey}
-      focusedNetIds={focusedNetIds}
-      focusedSessions={focusedSessions}
-      nodeIps={nodeIps}
-      onNodeClick={id => dispatch({ type: 'NODE_CLICKED', nodeId: id })}
-      onEdgeClick={(fromId, toId, edgeIndices) =>
-        dispatch({ type: 'EDGE_CLICKED', fromId, toId, edgeIndices })
-      }
-    />
+    <ZoomFrame height={520}>
+      <TopologyGraphSvg
+        graph={graph}
+        showRegistered={showRegistered}
+        showUnregistered={showUnregistered}
+        selectedNodeId={selectedNodeId}
+        selectedEdgeKey={selectedEdgeKey}
+        focusedNetIds={focusedNetIds}
+        focusedSessions={focusedSessions}
+        nodeIps={nodeIps}
+        onNodeClick={id => dispatch({ type: 'NODE_CLICKED', nodeId: id })}
+        onEdgeClick={(fromId, toId, edgeIndices) =>
+          dispatch({ type: 'EDGE_CLICKED', fromId, toId, edgeIndices })
+        }
+      />
+    </ZoomFrame>
   );
 }

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
@@ -5,8 +5,6 @@ import ZoomFrame from './ZoomFrame';
 export default function TopologyGraph() {
   const { graph } = useTopologyData();
   const {
-    showRegistered,
-    showUnregistered,
     selectedNodeId,
     selectedEdgeKey,
     focusedNetIds,
@@ -21,8 +19,6 @@ export default function TopologyGraph() {
     <ZoomFrame height={520}>
       <TopologyGraphSvg
         graph={graph}
-        showRegistered={showRegistered}
-        showUnregistered={showUnregistered}
         selectedNodeId={selectedNodeId}
         selectedEdgeKey={selectedEdgeKey}
         focusedNetIds={focusedNetIds}

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
@@ -4,8 +4,6 @@ import { buildTopoGraph, layoutNodes, svgDims, edgePath, inetEdgePath, edgeLabel
 
 interface Props {
   graph: GraphJson;
-  showRegistered?: boolean;
-  showUnregistered?: boolean;
   selectedNodeId?: string | null;
   selectedEdgeKey?: string | null;
   focusedNetIds?: Set<number> | null;
@@ -17,8 +15,6 @@ interface Props {
 
 export default function TopologyGraphSvg({
   graph,
-  showRegistered = true,
-  showUnregistered = true,
   selectedNodeId = null,
   selectedEdgeKey = null,
   focusedNetIds = null,
@@ -27,16 +23,7 @@ export default function TopologyGraphSvg({
   onNodeClick,
   onEdgeClick,
 }: Props) {
-  const { nodes: allNodes, edges: allEdges } = buildTopoGraph(graph);
-
-  const nodes = allNodes.filter(n => {
-    if (n.kind !== 'service') return true;
-    if (n.registered && !showRegistered) return false;
-    if (!n.registered && !showUnregistered) return false;
-    return true;
-  });
-  const visibleIds = new Set(nodes.map(n => n.id));
-  const edges = allEdges.filter(e => visibleIds.has(e.from) && visibleIds.has(e.to));
+  const { nodes, edges } = buildTopoGraph(graph);
 
   const pos = layoutNodes(nodes, edges);
   const { w, h } = svgDims(pos, nodes);

--- a/members/nullnet-server/ui/src/components/topology/ZoomFrame.tsx
+++ b/members/nullnet-server/ui/src/components/topology/ZoomFrame.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 
 const MIN_SCALE = 0.2;
 const MAX_SCALE = 4;
@@ -19,18 +19,24 @@ export default function ZoomFrame({ height, children }: Props) {
   const dragging = useRef<{ startX: number; startY: number; startTx: number; startTy: number } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
-    setZoom(prev => {
-      const factor = e.deltaY < 0 ? 1.1 : 0.9;
-      const newScale = Math.min(Math.max(prev.scale * factor, MIN_SCALE), MAX_SCALE);
-      const rect = containerRef.current!.getBoundingClientRect();
-      const mx = e.clientX - rect.left;
-      const my = e.clientY - rect.top;
-      const newTx = mx - (mx - prev.tx) * (newScale / prev.scale);
-      const newTy = my - (my - prev.ty) * (newScale / prev.scale);
-      return { scale: newScale, tx: newTx, ty: newTy };
-    });
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      setZoom(prev => {
+        const factor = e.deltaY < 0 ? 1.1 : 0.9;
+        const newScale = Math.min(Math.max(prev.scale * factor, MIN_SCALE), MAX_SCALE);
+        const rect = el.getBoundingClientRect();
+        const mx = e.clientX - rect.left;
+        const my = e.clientY - rect.top;
+        const newTx = mx - (mx - prev.tx) * (newScale / prev.scale);
+        const newTy = my - (my - prev.ty) * (newScale / prev.scale);
+        return { scale: newScale, tx: newTx, ty: newTy };
+      });
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
   }, []);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -40,9 +46,10 @@ export default function ZoomFrame({ height, children }: Props) {
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     if (!dragging.current) return;
-    const dx = e.clientX - dragging.current.startX;
-    const dy = e.clientY - dragging.current.startY;
-    setZoom(prev => ({ ...prev, tx: dragging.current!.startTx + dx, ty: dragging.current!.startTy + dy }));
+    const { startX, startY, startTx, startTy } = dragging.current;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    setZoom(prev => ({ ...prev, tx: startTx + dx, ty: startTy + dy }));
   }, []);
 
   const stopDrag = useCallback(() => { dragging.current = null; }, []);
@@ -60,8 +67,8 @@ export default function ZoomFrame({ height, children }: Props) {
           overflow: 'hidden',
           position: 'relative',
           cursor: dragging.current ? 'grabbing' : 'grab',
+          userSelect: 'none',
         }}
-        onWheel={handleWheel}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={stopDrag}

--- a/members/nullnet-server/ui/src/components/topology/ZoomFrame.tsx
+++ b/members/nullnet-server/ui/src/components/topology/ZoomFrame.tsx
@@ -1,0 +1,101 @@
+import { useRef, useState, useCallback } from 'react';
+
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 4;
+
+interface ZoomState {
+  scale: number;
+  tx: number;
+  ty: number;
+}
+
+interface Props {
+  height: number;
+  children: React.ReactNode;
+}
+
+export default function ZoomFrame({ height, children }: Props) {
+  const [zoom, setZoom] = useState<ZoomState>({ scale: 1, tx: 0, ty: 0 });
+  const dragging = useRef<{ startX: number; startY: number; startTx: number; startTy: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    setZoom(prev => {
+      const factor = e.deltaY < 0 ? 1.1 : 0.9;
+      const newScale = Math.min(Math.max(prev.scale * factor, MIN_SCALE), MAX_SCALE);
+      const rect = containerRef.current!.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const newTx = mx - (mx - prev.tx) * (newScale / prev.scale);
+      const newTy = my - (my - prev.ty) * (newScale / prev.scale);
+      return { scale: newScale, tx: newTx, ty: newTy };
+    });
+  }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    dragging.current = { startX: e.clientX, startY: e.clientY, startTx: zoom.tx, startTy: zoom.ty };
+  }, [zoom.tx, zoom.ty]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!dragging.current) return;
+    const dx = e.clientX - dragging.current.startX;
+    const dy = e.clientY - dragging.current.startY;
+    setZoom(prev => ({ ...prev, tx: dragging.current!.startTx + dx, ty: dragging.current!.startTy + dy }));
+  }, []);
+
+  const stopDrag = useCallback(() => { dragging.current = null; }, []);
+
+  const resetZoom = useCallback(() => setZoom({ scale: 1, tx: 0, ty: 0 }), []);
+
+  const isDefault = zoom.scale === 1 && zoom.tx === 0 && zoom.ty === 0;
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <div
+        ref={containerRef}
+        style={{
+          height,
+          overflow: 'hidden',
+          position: 'relative',
+          cursor: dragging.current ? 'grabbing' : 'grab',
+        }}
+        onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={stopDrag}
+        onMouseLeave={stopDrag}
+      >
+        <div
+          style={{
+            transform: `translate(${zoom.tx}px, ${zoom.ty}px) scale(${zoom.scale})`,
+            transformOrigin: '0 0',
+            width: '100%',
+          }}
+        >
+          {children}
+        </div>
+      </div>
+      {!isDefault && (
+        <button
+          onClick={resetZoom}
+          style={{
+            position: 'absolute',
+            bottom: 10,
+            right: 10,
+            background: 'rgba(255,255,255,.08)',
+            border: '1px solid rgba(255,255,255,.12)',
+            color: 'rgba(255,255,255,.6)',
+            fontSize: 10,
+            padding: '3px 8px',
+            borderRadius: 4,
+            cursor: 'pointer',
+          }}
+        >
+          reset view
+        </button>
+      )}
+    </div>
+  );
+}

--- a/members/nullnet-server/ui/src/pages/Dashboard.tsx
+++ b/members/nullnet-server/ui/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useApi } from '../hooks/useApi';
 import { useStack } from '../StackContext';
 import type { SessionJson, ServiceJson, NodeJson, PoolJson, GraphJson } from '../types';
 import TopologyGraphSvg from '../components/topology/TopologyGraphSvg';
+import ZoomFrame from '../components/topology/ZoomFrame';
 
 export default function Dashboard() {
   const { stack } = useStack();
@@ -64,11 +65,15 @@ export default function Dashboard() {
                 <span className="live-dot" />live · 5s
               </span>
             </div>
-            <div style={{ background: 'rgba(0,0,0,.25)', padding: 12 }}>
+            <div style={{ background: 'rgba(0,0,0,.25)' }}>
               {!graph && (
                 <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>loading topology…</div>
               )}
-              {graph && <TopologyGraphSvg graph={graph} />}
+              {graph && (
+                <ZoomFrame height={280}>
+                  <TopologyGraphSvg graph={graph} />
+                </ZoomFrame>
+              )}
             </div>
           </div>
 

--- a/members/nullnet-server/ui/src/pages/Topology.tsx
+++ b/members/nullnet-server/ui/src/pages/Topology.tsx
@@ -6,7 +6,7 @@ import TopologyPanel from '../components/topology/TopologyPanel';
 
 function TopologyView() {
   const { graph } = useTopologyData();
-  const { showRegistered, showUnregistered, panel, dispatch } = useTopologyUI();
+  const { panel, dispatch } = useTopologyUI();
   const { stack } = useStack();
 
   const nodeCount = graph?.nodes.length ?? 0;
@@ -39,23 +39,6 @@ function TopologyView() {
           </div>
         </div>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 2px', flexWrap: 'wrap' as const }}>
-          <span style={{ fontSize: 10, color: 'var(--t2)', letterSpacing: '.08em' }}>FILTER</span>
-          <button
-            className={`filter-chip${showRegistered ? ' on' : ''}`}
-            onClick={() => dispatch({ type: 'REGISTERED_TOGGLED' })}
-          >
-            Registered
-          </button>
-          <button
-            className={`filter-chip${showUnregistered ? ' on' : ''}`}
-            onClick={() => dispatch({ type: 'UNREGISTERED_TOGGLED' })}
-          >
-            Unregistered
-          </button>
-          <span style={{ width: 1, height: 18, background: 'var(--t3)', margin: '0 2px', display: 'inline-block' }} />
-          <span style={{ fontSize: 11, color: 'var(--t2)' }}>Click node or edge to inspect</span>
-        </div>
 
         <div className="card glass">
           <div className="card-head">

--- a/members/nullnet-server/ui/src/pages/Topology.tsx
+++ b/members/nullnet-server/ui/src/pages/Topology.tsx
@@ -70,7 +70,7 @@ function TopologyView() {
               ) : 'loading…'}
             </span>
           </div>
-          <div style={{ background: 'rgba(0,0,0,.25)', padding: 16, minHeight: 200 }}>
+          <div style={{ background: 'rgba(0,0,0,.25)', padding: 0 }}>
             {!graph && (
               <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
                 loading topology…


### PR DESCRIPTION
## Summary

This PR improves the topology viewer and the stack selection UX across the control plane UI.

---

## Changes

### Topology — Zoom & Pan Frame

Introduced a reusable `ZoomFrame` component (`ui/src/components/topology/ZoomFrame.tsx`) that wraps any SVG content with interactive zoom and pan:

- **Scroll to zoom** — mouse wheel zooms in/out centered on the cursor position (0.2× – 4× range).
- **Drag to pan** — click and drag to move the canvas freely.
- **Reset button** — a "reset view" button appears in the bottom-right corner whenever the view has been moved from its default position.
- **Fixed frame height** — the topology is rendered inside a fixed-height container (`overflow: hidden`) so it never pushes other content around.
- **No passive-listener warning** — the wheel handler is registered via `addEventListener` with `{ passive: false }` so `preventDefault` works correctly and the page does not scroll while zooming.
- **No text cursor on drag** — `userSelect: none` on the container prevents SVG text nodes from entering text-selection mode during a drag.

`ZoomFrame` is used in two places:

| Location | Height |
|---|---|
| Topology page (`TopologyGraph`) | 520 px |
| Dashboard mini-preview | 280 px |

### Stack Selector — Dropdown

Previously the stack name in the sidebar footer was a click-to-edit plain text field. It is now a proper dropdown:

- Clicking the stack name opens a popup list populated from the new `/api/stacks` endpoint (polled every 10 s).
- The currently active stack is highlighted.
- A **"type custom…"** option at the bottom of the list opens the original free-text input for stacks not yet known to the server.
- Double-clicking the name also opens the free-text input directly.
- The dropdown closes on outside click.

### Server — `GET /api/stacks`

New endpoint added to the Rust HTTP server:

```
GET /api/stacks  →  ["stack-a", "stack-b", ...]
```

Returns a sorted JSON array of all stack names currently held in the in-memory `StackMap`. No authentication required (consistent with all other read endpoints).

### Topology — Filter Bar Removed

The Registered / Unregistered filter chips were removed from the Topology page. All services are shown by default.
