### PR TITLE
Topology: full proxy chain highlighting + node text clipping

### DIFF
--- a/members/nullnet-server/src/http_server/chains.rs
+++ b/members/nullnet-server/src/http_server/chains.rs
@@ -80,8 +80,7 @@ fn collect_dep_net_ids(
             let Some(ip) = current_ip else {
                 break;
             };
-            let dep_client =
-                Client::new_service(current_name.clone(), ip, current_docker.clone());
+            let dep_client = Client::new_service(current_name.clone(), ip, current_docker.clone());
             let Some(ServiceInfo::Registered(dep_reg)) = stack_map.get(dep_name) else {
                 break;
             };

--- a/members/nullnet-server/src/http_server/chains.rs
+++ b/members/nullnet-server/src/http_server/chains.rs
@@ -87,15 +87,15 @@ fn collect_dep_net_ids(
 
             let mut found = false;
             'replica: for dep_replica in dep_reg.replicas() {
-                if let Some(ci) = dep_replica.clients().get(&dep_client) {
-                    if ci.net_id() != 0 {
-                        all_net_ids.push(ci.net_id());
-                        current_name = dep_name.clone();
-                        current_ip = Some(dep_replica.ip());
-                        current_docker = dep_replica.docker_container().map(String::from);
-                        found = true;
-                        break 'replica;
-                    }
+                if let Some(ci) = dep_replica.clients().get(&dep_client)
+                    && ci.net_id() != 0
+                {
+                    all_net_ids.push(ci.net_id());
+                    current_name = dep_name.clone();
+                    current_ip = Some(dep_replica.ip());
+                    current_docker = dep_replica.docker_container().map(String::from);
+                    found = true;
+                    break 'replica;
                 }
             }
 

--- a/members/nullnet-server/src/http_server/chains.rs
+++ b/members/nullnet-server/src/http_server/chains.rs
@@ -1,0 +1,108 @@
+use super::AppState;
+use crate::services::clients::Client;
+use crate::services::service_info::ServiceInfo;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+#[derive(Serialize)]
+struct ChainJson {
+    proxy_net_id: u32,
+    all_net_ids: Vec<u32>,
+}
+
+pub(super) async fn chains_handler(
+    Path(stack): Path<String>,
+    State(state): State<AppState>,
+) -> Response {
+    let services = state.services.read().await;
+    let Some(stack_map) = services.get(&stack) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let mut chains: Vec<ChainJson> = Vec::new();
+
+    for (service_name, info) in stack_map {
+        let ServiceInfo::Registered(reg) = info else {
+            continue;
+        };
+        for replica in reg.replicas() {
+            for (client, client_info) in replica.clients() {
+                if client.is_proxy().is_none() {
+                    continue;
+                }
+                let proxy_net_id = client_info.net_id();
+                if proxy_net_id == 0 {
+                    continue; // skip placeholder entries
+                }
+                let mut all_net_ids = vec![proxy_net_id];
+                collect_dep_net_ids(
+                    service_name,
+                    replica.ip(),
+                    replica.docker_container(),
+                    stack_map,
+                    &mut all_net_ids,
+                );
+                chains.push(ChainJson {
+                    proxy_net_id,
+                    all_net_ids,
+                });
+            }
+        }
+    }
+
+    chains.sort_by_key(|c| c.proxy_net_id);
+
+    axum::Json(chains).into_response()
+}
+
+/// Recursively follow `proxy_deps` from `service_name`/`replica_ip`, appending
+/// the net_id of each live service-to-service connection to `all_net_ids`.
+fn collect_dep_net_ids(
+    service_name: &str,
+    replica_ip: IpAddr,
+    replica_docker: Option<&str>,
+    stack_map: &HashMap<String, ServiceInfo>,
+    all_net_ids: &mut Vec<u32>,
+) {
+    let Some(service_info) = stack_map.get(service_name) else {
+        return;
+    };
+
+    for branch in service_info.proxy_deps() {
+        let mut current_name = service_name.to_string();
+        let mut current_ip = Some(replica_ip);
+        let mut current_docker: Option<String> = replica_docker.map(String::from);
+
+        for dep_name in branch {
+            let Some(ip) = current_ip else {
+                break;
+            };
+            let dep_client =
+                Client::new_service(current_name.clone(), ip, current_docker.clone());
+            let Some(ServiceInfo::Registered(dep_reg)) = stack_map.get(dep_name) else {
+                break;
+            };
+
+            let mut found = false;
+            'replica: for dep_replica in dep_reg.replicas() {
+                if let Some(ci) = dep_replica.clients().get(&dep_client) {
+                    if ci.net_id() != 0 {
+                        all_net_ids.push(ci.net_id());
+                        current_name = dep_name.clone();
+                        current_ip = Some(dep_replica.ip());
+                        current_docker = dep_replica.docker_container().map(String::from);
+                        found = true;
+                        break 'replica;
+                    }
+                }
+            }
+
+            if !found {
+                break;
+            }
+        }
+    }
+}

--- a/members/nullnet-server/src/http_server/mod.rs
+++ b/members/nullnet-server/src/http_server/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 mod certificates;
+mod chains;
 mod config;
 mod events;
 mod events_stream;
@@ -40,6 +41,7 @@ pub async fn serve(state: AppState) {
         .route("/api/graph/{stack}", get(graph::graph_handler))
         .route("/api/sessions", get(sessions::list_handler))
         .route("/api/sessions/{id}", delete(sessions::teardown_handler))
+        .route("/api/chains/{stack}", get(chains::chains_handler))
         .route("/api/certificates", get(certificates::list_handler))
         .route(
             "/api/certificates/request",

--- a/members/nullnet-server/ui/src/components/topology/EdgePanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/EdgePanel.tsx
@@ -1,11 +1,21 @@
+import { useMemo } from 'react';
 import type { GraphEdgeJson } from '../../types';
 import { spRow, spKey, spCode } from './panelStyles';
+import { useTopologyData } from './TopologyContext';
 
 interface Props {
   edges: GraphEdgeJson[];
 }
 
 export default function EdgePanel({ edges }: Props) {
+  const { chains } = useTopologyData();
+
+  const chainByProxyNetId = useMemo(() => {
+    const m = new Map<number, number[]>();
+    for (const c of chains ?? []) m.set(c.proxy_net_id, c.all_net_ids);
+    return m;
+  }, [chains]);
+
   if (edges.length === 0) return null;
   const first = edges[0];
 
@@ -46,7 +56,9 @@ export default function EdgePanel({ edges }: Props) {
         }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
             <span style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 10, color: 'var(--cyan)' }}>
-              net {e.net_id}
+              {e.via_proxy && chainByProxyNetId.has(e.net_id)
+                ? `nets ${chainByProxyNetId.get(e.net_id)!.join(', ')}`
+                : `net ${e.net_id}`}
             </span>
             {e.setup_ms > 0 && (
               <span style={{ fontSize: 10, color: 'var(--t2)' }}>{e.setup_ms}ms setup</span>

--- a/members/nullnet-server/ui/src/components/topology/InternetPanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/InternetPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { SessionJson } from '../../types';
 import { spRow, spKey, SpSep } from './panelStyles';
 import { useTopologyData, useTopologyUI } from './TopologyContext';
@@ -25,8 +25,14 @@ function formatTime(unix: number): string {
 }
 
 export default function InternetPanel() {
-  const { sessions } = useTopologyData();
+  const { sessions, chains } = useTopologyData();
   const { focusedClientIp, dispatch } = useTopologyUI();
+
+  const chainByProxyNetId = useMemo(() => {
+    const m = new Map<number, number[]>();
+    for (const c of chains ?? []) m.set(c.proxy_net_id, c.all_net_ids);
+    return m;
+  }, [chains]);
   const [expanded, setExpanded] = useState(new Set<string>());
 
   const sessionList = sessions ?? [];
@@ -110,7 +116,9 @@ export default function InternetPanel() {
                   </div>
                   <div style={{ flexShrink: 0, textAlign: 'right' as const }}>
                     <div style={{ fontSize: 9.5, fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
-                      net {s.network_id}
+                      {chainByProxyNetId.has(s.network_id)
+                        ? `nets ${chainByProxyNetId.get(s.network_id)!.join(', ')}`
+                        : `net ${s.network_id}`}
                     </div>
                     <div style={{ fontSize: 9, color: 'var(--t2)' }}>{formatTime(s.created_at)}</div>
                   </div>

--- a/members/nullnet-server/ui/src/components/topology/TopologyContext.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyContext.tsx
@@ -112,7 +112,7 @@ export function TopologyProvider({
   const { data: graph, refetch } = useApi<GraphJson>(`/api/graph/${stack}`);
   const { data: services } = useApi<ServiceJson[]>(`/api/services/${stack}`, 5000);
   const { data: sessions } = useApi<SessionJson[]>('/api/sessions', 5000);
-  const { data: chains } = useApi<ChainJson[]>(`/api/chains/${stack}`, 5000);
+  const { data: chains, refetch: refetchChains } = useApi<ChainJson[]>(`/api/chains/${stack}`);
 
   const [uiState, dispatch] = useReducer(uiReducer, initialUIState);
 
@@ -125,9 +125,11 @@ export function TopologyProvider({
     }
   }, [stack]);
 
-  // SSE: re-fetch the graph whenever a session is created or torn down.
+  // SSE: re-fetch graph and chains whenever a session is created or torn down.
   const refetchRef = useRef(refetch);
   refetchRef.current = refetch;
+  const refetchChainsRef = useRef(refetchChains);
+  refetchChainsRef.current = refetchChains;
   useEffect(() => {
     const es = new EventSource('/api/events/stream');
     es.onmessage = (ev) => {
@@ -135,6 +137,7 @@ export function TopologyProvider({
         const event = JSON.parse(ev.data);
         if (event.type === 'session_created' || event.type === 'session_torn_down') {
           refetchRef.current();
+          refetchChainsRef.current();
         }
       } catch { /* ignore */ }
     };

--- a/members/nullnet-server/ui/src/components/topology/TopologyContext.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useMemo, useReducer, useRef } from 'react';
-import type { GraphJson, ServiceJson, SessionJson } from '../../types';
+import type { ChainJson, GraphJson, ServiceJson, SessionJson } from '../../types';
 import type { PanelState } from './types';
 import { INTERNET_ID } from './types';
 import { useApi } from '../../hooks/useApi';
@@ -10,12 +10,14 @@ interface TopologyData {
   graph: GraphJson | null;
   services: ServiceJson[] | null;
   sessions: SessionJson[] | null;
+  chains: ChainJson[] | null;
 }
 
 const TopologyDataContext = createContext<TopologyData>({
   graph: null,
   services: null,
   sessions: null,
+  chains: null,
 });
 
 // ── UI reducer ────────────────────────────────────────────────────────────────
@@ -110,6 +112,7 @@ export function TopologyProvider({
   const { data: graph, refetch } = useApi<GraphJson>(`/api/graph/${stack}`);
   const { data: services } = useApi<ServiceJson[]>(`/api/services/${stack}`, 5000);
   const { data: sessions } = useApi<SessionJson[]>('/api/sessions', 5000);
+  const { data: chains } = useApi<ChainJson[]>(`/api/chains/${stack}`, 5000);
 
   const [uiState, dispatch] = useReducer(uiReducer, initialUIState);
 
@@ -154,10 +157,19 @@ export function TopologyProvider({
     [uiState.focusedClientIp, sessions],
   );
 
-  const focusedNetIds = useMemo<Set<number> | null>(
-    () => (focusedSessions ? new Set(focusedSessions.map(s => s.network_id)) : null),
-    [focusedSessions],
-  );
+  const focusedNetIds = useMemo<Set<number> | null>(() => {
+    if (!focusedSessions) return null;
+    const proxyNetIds = new Set(focusedSessions.map(s => s.network_id));
+    const all = new Set(proxyNetIds);
+    if (chains) {
+      for (const chain of chains) {
+        if (proxyNetIds.has(chain.proxy_net_id)) {
+          for (const id of chain.all_net_ids) all.add(id);
+        }
+      }
+    }
+    return all;
+  }, [focusedSessions, chains]);
 
   const selectedNodeId =
     uiState.panel?.type === 'node' ? uiState.panel.nodeId :
@@ -170,7 +182,7 @@ export function TopologyProvider({
       : null;
 
   return (
-    <TopologyDataContext.Provider value={{ graph, services, sessions }}>
+    <TopologyDataContext.Provider value={{ graph, services, sessions, chains }}>
       <TopologyUIContext.Provider
         value={{
           ...uiState,

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
@@ -194,12 +194,13 @@ export default function TopologyGraphSvg({
       })}
 
       {/* Nodes */}
-      {nodes.map(n => {
+      {nodes.map((n, ni) => {
         const p = pos.get(n.id);
         if (!p) return null;
         const isSel = n.id === selectedNodeId;
         const nodeDimmed = focusedNetIds != null && !focusedNodeIds.has(n.id);
         const clickHandler = onNodeClick ? () => onNodeClick(n.id) : undefined;
+        const clipId = `nc-${ni}`;
 
         if (n.kind === 'internet') {
           return (
@@ -222,6 +223,11 @@ export default function TopologyGraphSvg({
         if (n.kind === 'proxy') {
           return (
             <g key={n.id} onClick={clickHandler} style={{ cursor: onNodeClick ? 'pointer' : 'default', opacity: nodeDimmed ? 0.12 : 1 }}>
+              <defs>
+                <clipPath id={clipId}>
+                  <rect x={p.x + 4} y={p.y + 2} width={NODE_W - 8} height={NODE_H - 4} />
+                </clipPath>
+              </defs>
               {isSel && (
                 <rect x={p.x - 3} y={p.y - 3} width={NODE_W + 6} height={NODE_H + 6} rx="10"
                   fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
@@ -230,8 +236,10 @@ export default function TopologyGraphSvg({
                 fill="rgba(251,191,36,.06)" stroke="rgba(251,191,36,.4)"
                 strokeWidth="1" strokeDasharray="5 3" filter="url(#gT)" />
               <circle cx={p.x + 15} cy={p.y + 22} r="3.5" fill="#fbbf24" />
-              <text x={p.x + 27} y={p.y + 20} fill="rgba(251,191,36,.9)" fontSize="9.5" fontWeight="500" pointerEvents="none">proxy</text>
-              <text x={p.x + 27} y={p.y + 32} fill="rgba(255,255,255,.4)" fontSize="8" fontFamily="'JetBrains Mono',monospace" pointerEvents="none">{n.id}</text>
+              <g clipPath={`url(#${clipId})`} pointerEvents="none">
+                <text x={p.x + 27} y={p.y + 20} fill="rgba(251,191,36,.9)" fontSize="9.5" fontWeight="500">proxy</text>
+                <text x={p.x + 27} y={p.y + 32} fill="rgba(255,255,255,.4)" fontSize="8" fontFamily="'JetBrains Mono',monospace">{n.id}</text>
+              </g>
             </g>
           );
         }
@@ -241,6 +249,12 @@ export default function TopologyGraphSvg({
         const ip = nodeIps.get(n.id);
         return (
           <g key={n.id} onClick={clickHandler} style={{ cursor: onNodeClick ? 'pointer' : 'default', opacity: nodeDimmed ? 0.12 : 1 }}>
+            <title>{n.id}</title>
+            <defs>
+              <clipPath id={clipId}>
+                <rect x={p.x + 4} y={p.y + 2} width={NODE_W - 8} height={NODE_H - 4} />
+              </clipPath>
+            </defs>
             {isSel && (
               <rect x={p.x - 3} y={p.y - 3} width={NODE_W + 6} height={NODE_H + 6} rx="10"
                 fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
@@ -248,14 +262,16 @@ export default function TopologyGraphSvg({
             <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
               fill="rgba(255,255,255,.04)" stroke={strokeColor} strokeWidth="1" filter="url(#gT)" />
             <circle cx={p.x + 15} cy={p.y + 17} r="3.5" fill={color} />
-            <text x={p.x + 27} y={p.y + 20} fill="rgba(255,255,255,.85)" fontSize="9.5" fontWeight="500" pointerEvents="none">{n.id}</text>
-            {ip && (
-              <text x={p.x + 27} y={p.y + 31} fill="rgba(255,255,255,.35)" fontSize="8" fontFamily="'JetBrains Mono',monospace" pointerEvents="none">{ip}</text>
-            )}
-            <text x={p.x + 27} y={p.y + (ip ? 42 : 31)} fill="rgba(255,255,255,.3)" fontSize="7.5" pointerEvents="none">
-              {n.registered ? `${n.active_replica_count}/${n.replica_count} active` : 'unregistered'}
-              {n.entry_point ? ' · entry' : ''}
-            </text>
+            <g clipPath={`url(#${clipId})`} pointerEvents="none">
+              <text x={p.x + 27} y={p.y + 20} fill="rgba(255,255,255,.85)" fontSize="9.5" fontWeight="500">{n.id}</text>
+              {ip && (
+                <text x={p.x + 27} y={p.y + 31} fill="rgba(255,255,255,.35)" fontSize="8" fontFamily="'JetBrains Mono',monospace">{ip}</text>
+              )}
+              <text x={p.x + 27} y={p.y + (ip ? 42 : 31)} fill="rgba(255,255,255,.3)" fontSize="7.5">
+                {n.registered ? `${n.active_replica_count}/${n.replica_count} active` : 'unregistered'}
+                {n.entry_point ? ' · entry' : ''}
+              </text>
+            </g>
           </g>
         );
       })}

--- a/members/nullnet-server/ui/src/pages/Topology.tsx
+++ b/members/nullnet-server/ui/src/pages/Topology.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import Layout from '../components/Layout';
 import { useStack } from '../StackContext';
 import { TopologyProvider, useTopologyData, useTopologyUI } from '../components/topology/TopologyContext';
@@ -5,8 +6,14 @@ import TopologyGraph from '../components/topology/TopologyGraph';
 import TopologyPanel from '../components/topology/TopologyPanel';
 
 function TopologyView() {
-  const { graph } = useTopologyData();
+  const { graph, chains } = useTopologyData();
   const { panel, dispatch } = useTopologyUI();
+
+  const chainByProxyNetId = useMemo(() => {
+    const m = new Map<number, number[]>();
+    for (const c of chains ?? []) m.set(c.proxy_net_id, c.all_net_ids);
+    return m;
+  }, [chains]);
   const { stack } = useStack();
 
   const nodeCount = graph?.nodes.length ?? 0;
@@ -112,7 +119,11 @@ function TopologyView() {
                       {e.via_proxy ?? <span style={{ color: 'var(--t3)' }}>—</span>}
                     </td>
                     <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.to}</td>
-                    <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>{e.net_id}</td>
+                    <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
+                      {e.via_proxy && chainByProxyNetId.has(e.net_id)
+                        ? chainByProxyNetId.get(e.net_id)!.join(', ')
+                        : e.net_id}
+                    </td>
                     <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
                       {e.setup_ms > 0 ? `${e.setup_ms}ms` : '—'}
                     </td>

--- a/members/nullnet-server/ui/src/types.ts
+++ b/members/nullnet-server/ui/src/types.ts
@@ -128,3 +128,8 @@ export interface GraphJson {
   nodes: GraphNodeJson[];
   edges: GraphEdgeJson[];
 }
+
+export interface ChainJson {
+  proxy_net_id: number;
+  all_net_ids: number[];
+}


### PR DESCRIPTION
## Problem

Clicking a client in the topology view only highlighted the direct proxy
hop (`Internet → Proxy → S1`). Any downstream service-to-service
dependencies (`S1 → S2 → …`) stayed dimmed, making it impossible to
trace a request's full path through the graph.

Additionally, long service names overflowed the node rectangle,
overlapping adjacent nodes and edges.

## Changes

### Backend — `GET /api/chains/{stack}`

New endpoint that, for each live proxy session, walks the service's
`proxy_deps` branches transitively and returns the full set of net IDs
involved in the chain:

```json
[
  { "proxy_net_id": 100, "all_net_ids": [100, 200, 300] }
]
```

The lookup is **replica-precise**: service-to-service clients are keyed
by source replica IP, so two proxy clients landing on different replicas
of the same service each get their own independent dep chain. Clients
sharing a replica share the same downstream tunnels and are represented
correctly.

### Frontend — accurate chain highlight

`TopologyContext` fetches `/api/chains/{stack}`  and uses it to expand `focusedNetIds` when a client is
clicked. The existing graph-traversal highlight logic then lights up
every edge in the chain, not just the proxy hop.

### Frontend — chain net IDs in all three places

All three locations that display net IDs now show the full chain for
proxy sessions (e.g. `nets 100, 200`) instead of the single proxy net
ID:

- **Active Connections table** — Net ID column
- **Edge panel** (side drawer, session cards)
- **Internet panel** (side drawer, per-client row)

Direct service-to-service edges retain their own single net ID display
unchanged.

### Frontend — node text clipping

Each service and proxy node now defines an inline SVG `<clipPath>` that
matches its bounding box (4 px inset). Text lines are rendered inside a
`<g clipPath="…">` so long names are clipped cleanly at the node edge.
Background rect, status dot, and selection outline are outside the clip
and render normally. Service nodes also carry a `<title>` so the full
name is visible on hover.