### PR TITLE
Pause idle Docker services and resume on demand

### DIFF
--- a/members/nullnet-client/src/control_channel.rs
+++ b/members/nullnet-client/src/control_channel.rs
@@ -5,14 +5,15 @@ use crate::triggers::TriggersState;
 use ipnetwork::Ipv4Network;
 use nullnet_grpc_lib::NullnetGrpcInterface;
 use nullnet_grpc_lib::nullnet_grpc::{
-    AgentControlChannelAckFailed, AgentControlChannelClosed, AgentControlChannelEstablished,
-    AgentDnatInstallFailed, AgentDnatRemovalFailed, AgentHostMappingFailed,
-    AgentVlanSetupCompleted, AgentVlanSetupFailed, AgentVlanTeardownFailed,
-    AgentVxlanSetupCompleted, AgentVxlanSetupFailed, AgentVxlanTeardownFailed,
+    AgentContainerResumeFailed, AgentContainerSuspendFailed, AgentControlChannelAckFailed,
+    AgentControlChannelClosed, AgentControlChannelEstablished, AgentDnatInstallFailed,
+    AgentDnatRemovalFailed, AgentHostMappingFailed, AgentVlanSetupCompleted, AgentVlanSetupFailed,
+    AgentVlanTeardownFailed, AgentVxlanSetupCompleted, AgentVxlanSetupFailed,
+    AgentVxlanTeardownFailed,
 };
 use nullnet_grpc_lib::nullnet_grpc::{
-    AgentEvent, HostMapping, MsgId, VlanSetup, VlanTeardown, VxlanSetup, VxlanTeardown,
-    agent_event::Event as AgentEventKind, net_message,
+    AgentEvent, ContainerResume, ContainerSuspend, HostMapping, MsgId, VlanSetup, VlanTeardown,
+    VxlanSetup, VxlanTeardown, agent_event::Event as AgentEventKind, net_message,
 };
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::net::Ipv4Addr;
@@ -101,6 +102,16 @@ pub(crate) async fn control_channel(
                         host_mappings_state,
                         server,
                     );
+                });
+            }
+            Some(net_message::Message::ContainerSuspend(container_suspend)) => {
+                tokio::spawn(async move {
+                    handle_container_suspend(container_suspend, server);
+                });
+            }
+            Some(net_message::Message::ContainerResume(container_resume)) => {
+                tokio::spawn(async move {
+                    let _ = handle_container_resume(container_resume, outbound, server).await;
                 });
             }
             None => {}
@@ -474,6 +485,126 @@ fn handle_vxlan_teardown(
         "VXLAN teardown completed in {} ms",
         init_t.elapsed().as_millis()
     );
+}
+
+/// Pause an idle container. Fire-and-forget: the server marks the replica
+/// suspended optimistically, so we only report a structured event on failure.
+/// An already-paused container is treated as success (e.g. after a server
+/// restart re-issues the command).
+fn handle_container_suspend(message: ContainerSuspend, grpc: NullnetGrpcInterface) {
+    let container = message.docker_container;
+    let init_t = std::time::Instant::now();
+    match docker_action("pause", &container, "is already paused") {
+        Ok(()) => println!(
+            "Paused container '{container}' in {} ms",
+            init_t.elapsed().as_millis()
+        ),
+        Err(error_message) => fire_event(
+            &grpc,
+            AgentEventKind::ContainerSuspendFailed(AgentContainerSuspendFailed {
+                docker_container: container,
+                error_message,
+            }),
+        ),
+    }
+}
+
+/// Resume a suspended container, confirm it is actually running, then ack so the
+/// server only returns the upstream to the proxy once the service is serving.
+/// On any failure we report an event and deliberately do NOT ack — the server's
+/// resume wait then times out and surfaces the failure to the proxy.
+async fn handle_container_resume(
+    message: ContainerResume,
+    outbound: Sender<MsgId>,
+    grpc: NullnetGrpcInterface,
+) -> Result<(), Error> {
+    let msg_id = message
+        .msg_id
+        .ok_or("Missing message ID in container resume message")
+        .handle_err(location!())?;
+    let container = message.docker_container;
+    let init_t = std::time::Instant::now();
+
+    // unpause (tolerate an already-running container)
+    if let Err(error_message) = docker_action("unpause", &container, "is not paused") {
+        fire_event(
+            &grpc,
+            AgentEventKind::ContainerResumeFailed(AgentContainerResumeFailed {
+                docker_container: container,
+                error_message,
+            }),
+        );
+        return Ok(());
+    }
+
+    // confirm it is running and not paused before acking; unpause preserves the
+    // listening socket, so a running container is immediately serving.
+    if !container_running(&container) {
+        fire_event(
+            &grpc,
+            AgentEventKind::ContainerResumeFailed(AgentContainerResumeFailed {
+                docker_container: container,
+                error_message: "container not running after unpause".to_string(),
+            }),
+        );
+        return Ok(());
+    }
+
+    println!(
+        "Resumed container '{container}' in {} ms",
+        init_t.elapsed().as_millis()
+    );
+
+    // acknowledge — tells the server the service is serving again
+    if outbound.send(msg_id.clone()).await.is_err() {
+        fire_event(
+            &grpc,
+            AgentEventKind::ControlChannelAckFailed(AgentControlChannelAckFailed {
+                msg_id: msg_id.id.clone(),
+                message_type: "container_resume".to_string(),
+            }),
+        );
+    }
+
+    Ok(())
+}
+
+/// Run `docker <action> <container>`, treating a non-zero exit whose stderr
+/// contains `benign` (the container is already in the target state) as success.
+fn docker_action(action: &str, container: &str, benign: &str) -> Result<(), String> {
+    match std::process::Command::new("docker")
+        .args([action, container])
+        .output()
+    {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if stderr.contains(benign) {
+                Ok(())
+            } else {
+                Err(stderr.trim().to_string())
+            }
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// True when the container is running and not paused.
+fn container_running(container: &str) -> bool {
+    match std::process::Command::new("docker")
+        .args([
+            "inspect",
+            "-f",
+            "{{.State.Running}} {{.State.Paused}}",
+            container,
+        ])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            String::from_utf8_lossy(&out.stdout).trim() == "true false"
+        }
+        _ => false,
+    }
 }
 
 fn add_host_mapping(hm: &HostMapping, docker_container: Option<&str>) -> Result<(), Error> {

--- a/members/nullnet-grpc-lib/proto/nullnet_grpc.proto
+++ b/members/nullnet-grpc-lib/proto/nullnet_grpc.proto
@@ -55,7 +55,24 @@ message NetMessage {
     // VXLAN setup and teardown
     VxlanSetup vxlan_setup = 3;
     VxlanTeardown vxlan_teardown = 4;
+    // Docker container suspend (fire-and-forget) and resume (ack'd)
+    ContainerSuspend container_suspend = 5;
+    ContainerResume container_resume = 6;
   }
+}
+
+// Pause an idle Docker container: the client runs `docker pause`. No ack —
+// the server treats the replica as suspended optimistically.
+message ContainerSuspend {
+  string docker_container = 1;
+}
+
+// Resume a suspended Docker container: the client runs `docker unpause`,
+// confirms it is running, then acks via `msg_id` so the server only returns
+// the upstream to the proxy once the service is serving again.
+message ContainerResume {
+  MsgId msg_id = 1;
+  string docker_container = 2;
 }
 
 message VlanSetup {
@@ -195,6 +212,8 @@ message AgentEvent {
     AgentServicesListUpdateFailed services_list_update_failed = 10;
     AgentBackendTriggerSendFailed backend_trigger_send_failed = 11;
     AgentFirewallRulesLoadFailed  firewall_rules_load_failed  = 12;
+    AgentContainerSuspendFailed   container_suspend_failed    = 24;
+    AgentContainerResumeFailed    container_resume_failed     = 25;
     // Client info events
     AgentVxlanSetupCompleted      vxlan_setup_completed      = 13;
     AgentVlanSetupCompleted       vlan_setup_completed       = 14;
@@ -224,6 +243,8 @@ message AgentControlChannelAckFailed { string msg_id = 1; string message_type = 
 message AgentServicesListUpdateFailed { string error_message = 1; uint32 num_services = 2; }
 message AgentBackendTriggerSendFailed { string service_name = 1; uint32 port = 2; string error_message = 3; }
 message AgentFirewallRulesLoadFailed  { string path = 1; string error_message = 2; }
+message AgentContainerSuspendFailed  { string docker_container = 1; string error_message = 2; }
+message AgentContainerResumeFailed   { string docker_container = 1; string error_message = 2; }
 message AgentVxlanSetupCompleted    { uint32 vxlan_id = 1; string ns_name = 2; }
 message AgentVlanSetupCompleted     { uint32 vlan_id = 1; }
 message AgentControlChannelEstablished {}

--- a/members/nullnet-grpc-lib/src/proto/nullnet_grpc.rs
+++ b/members/nullnet-grpc-lib/src/proto/nullnet_grpc.rs
@@ -6,7 +6,7 @@ pub struct NetType {
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NetMessage {
-    #[prost(oneof = "net_message::Message", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "net_message::Message", tags = "1, 2, 3, 4, 5, 6")]
     pub message: ::core::option::Option<net_message::Message>,
 }
 /// Nested message and enum types in `NetMessage`.
@@ -23,7 +23,29 @@ pub mod net_message {
         VxlanSetup(super::VxlanSetup),
         #[prost(message, tag = "4")]
         VxlanTeardown(super::VxlanTeardown),
+        /// Docker container suspend (fire-and-forget) and resume (ack'd)
+        #[prost(message, tag = "5")]
+        ContainerSuspend(super::ContainerSuspend),
+        #[prost(message, tag = "6")]
+        ContainerResume(super::ContainerResume),
     }
+}
+/// Pause an idle Docker container: the client runs `docker pause`. No ack —
+/// the server treats the replica as suspended optimistically.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ContainerSuspend {
+    #[prost(string, tag = "1")]
+    pub docker_container: ::prost::alloc::string::String,
+}
+/// Resume a suspended Docker container: the client runs `docker unpause`,
+/// confirms it is running, then acks via `msg_id` so the server only returns
+/// the upstream to the proxy once the service is serving again.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ContainerResume {
+    #[prost(message, optional, tag = "1")]
+    pub msg_id: ::core::option::Option<MsgId>,
+    #[prost(string, tag = "2")]
+    pub docker_container: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct VlanSetup {
@@ -190,7 +212,7 @@ pub struct Empty {}
 pub struct AgentEvent {
     #[prost(
         oneof = "agent_event::Event",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23, 22"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 24, 25, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23, 22"
     )]
     pub event: ::core::option::Option<agent_event::Event>,
 }
@@ -223,6 +245,10 @@ pub mod agent_event {
         BackendTriggerSendFailed(super::AgentBackendTriggerSendFailed),
         #[prost(message, tag = "12")]
         FirewallRulesLoadFailed(super::AgentFirewallRulesLoadFailed),
+        #[prost(message, tag = "24")]
+        ContainerSuspendFailed(super::AgentContainerSuspendFailed),
+        #[prost(message, tag = "25")]
+        ContainerResumeFailed(super::AgentContainerResumeFailed),
         /// Client info events
         #[prost(message, tag = "13")]
         VxlanSetupCompleted(super::AgentVxlanSetupCompleted),
@@ -336,6 +362,20 @@ pub struct AgentBackendTriggerSendFailed {
 pub struct AgentFirewallRulesLoadFailed {
     #[prost(string, tag = "1")]
     pub path: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub error_message: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentContainerSuspendFailed {
+    #[prost(string, tag = "1")]
+    pub docker_container: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub error_message: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AgentContainerResumeFailed {
+    #[prost(string, tag = "1")]
+    pub docker_container: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub error_message: ::prost::alloc::string::String,
 }

--- a/members/nullnet-server/src/events.rs
+++ b/members/nullnet-server/src/events.rs
@@ -197,6 +197,16 @@ pub(crate) enum Event {
         error_message: String,
         timestamp: u64,
     },
+    ContainerSuspendFailed {
+        docker_container: String,
+        error_message: String,
+        timestamp: u64,
+    },
+    ContainerResumeFailed {
+        docker_container: String,
+        error_message: String,
+        timestamp: u64,
+    },
 
     // --- Client info events ---
     VxlanSetupCompleted {
@@ -304,6 +314,8 @@ impl Event {
             Self::ServicesListUpdateFailed { .. } => "services_list_update_failed",
             Self::BackendTriggerSendFailed { .. } => "backend_trigger_send_failed",
             Self::FirewallRulesLoadFailed { .. } => "firewall_rules_load_failed",
+            Self::ContainerSuspendFailed { .. } => "container_suspend_failed",
+            Self::ContainerResumeFailed { .. } => "container_resume_failed",
             Self::VxlanSetupCompleted { .. } => "vxlan_setup_completed",
             Self::VlanSetupCompleted { .. } => "vlan_setup_completed",
             Self::ControlChannelEstablished { .. } => "control_channel_established",
@@ -364,6 +376,8 @@ impl Event {
             | Self::ServicesListUpdateFailed { .. }
             | Self::BackendTriggerSendFailed { .. }
             | Self::FirewallRulesLoadFailed { .. }
+            | Self::ContainerSuspendFailed { .. }
+            | Self::ContainerResumeFailed { .. }
             | Self::UpstreamLookupFailed { .. }
             | Self::ProxyRequestMissingHost { .. }
             | Self::ProxyRequestInvalidHost { .. }
@@ -649,6 +663,25 @@ impl Event {
     pub(crate) fn firewall_rules_load_failed(path: String, error_message: String) -> Self {
         Self::FirewallRulesLoadFailed {
             path,
+            error_message,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn container_suspend_failed(
+        docker_container: String,
+        error_message: String,
+    ) -> Self {
+        Self::ContainerSuspendFailed {
+            docker_container,
+            error_message,
+            timestamp: now_secs(),
+        }
+    }
+
+    pub(crate) fn container_resume_failed(docker_container: String, error_message: String) -> Self {
+        Self::ContainerResumeFailed {
+            docker_container,
             error_message,
             timestamp: now_secs(),
         }

--- a/members/nullnet-server/src/graphviz.rs
+++ b/members/nullnet-server/src/graphviz.rs
@@ -131,7 +131,9 @@ impl ServiceInfo {
                         ))
                 })
                 .count();
-            return format!("{name} ({active}/{total})");
+            let paused = reg.replicas().iter().filter(|r| r.suspended()).count();
+            // Counts go on their own line (\n) so the node doesn't grow too wide.
+            return format!("{name}\\n{active} active / {paused} paused / {total} total");
         }
         name.to_string()
     }
@@ -181,6 +183,7 @@ struct GraphNodeJson {
     entry_point: bool,
     replica_count: usize,
     active_replica_count: usize,
+    paused_replica_count: usize,
 }
 
 #[derive(Serialize)]
@@ -201,30 +204,33 @@ pub(crate) fn render_graph_json(services: &HashMap<String, ServiceInfo>) -> Grap
         .map(|(name, info)| {
             let registered = matches!(info, ServiceInfo::Registered(_));
             let entry_point = info.timeout().is_some();
-            let (replica_count, active_replica_count) = if let ServiceInfo::Registered(reg) = info {
-                let total = reg.replicas().len();
-                let active = reg
-                    .replicas()
-                    .iter()
-                    .filter(|r| {
-                        !r.clients().is_empty()
-                            || initiators.contains(&(
-                                name.clone(),
-                                r.ip(),
-                                r.docker_container().map(String::from),
-                            ))
-                    })
-                    .count();
-                (total, active)
-            } else {
-                (0, 0)
-            };
+            let (replica_count, active_replica_count, paused_replica_count) =
+                if let ServiceInfo::Registered(reg) = info {
+                    let total = reg.replicas().len();
+                    let active = reg
+                        .replicas()
+                        .iter()
+                        .filter(|r| {
+                            !r.clients().is_empty()
+                                || initiators.contains(&(
+                                    name.clone(),
+                                    r.ip(),
+                                    r.docker_container().map(String::from),
+                                ))
+                        })
+                        .count();
+                    let paused = reg.replicas().iter().filter(|r| r.suspended()).count();
+                    (total, active, paused)
+                } else {
+                    (0, 0, 0)
+                };
             GraphNodeJson {
                 id: name.clone(),
                 registered,
                 entry_point,
                 replica_count,
                 active_replica_count,
+                paused_replica_count,
             }
         })
         .collect();

--- a/members/nullnet-server/src/graphviz.rs
+++ b/members/nullnet-server/src/graphviz.rs
@@ -59,7 +59,7 @@ pub(crate) fn render_graphviz(services: &HashMap<String, ServiceInfo>) -> String
         let style = info.graphviz_style();
         let label = info.graphviz_label(name, &initiators);
         let _ =
-            writeln!(graphviz, "\t\"{name}\" [label=\"{label}\"] {style};").handle_err(location!());
+            writeln!(graphviz, "\t\"{name}\" [label=<{label}>] {style};").handle_err(location!());
         if let ServiceInfo::Registered(registered) = info {
             let mut edges: Vec<_> = registered
                 .replicas()
@@ -132,8 +132,11 @@ impl ServiceInfo {
                 })
                 .count();
             let paused = reg.replicas().iter().filter(|r| r.suspended()).count();
-            // Counts go on their own line (\n) so the node doesn't grow too wide.
-            return format!("{name}\\n{active} active / {paused} paused / {total} total");
+            // HTML-like label: counts on their own line at edge-label size (9) so
+            // the node stays narrow and the name keeps the default size.
+            return format!(
+                "{name}<BR/><FONT POINT-SIZE=\"9\">{active} active / {paused} paused / {total} total</FONT>"
+            );
         }
         name.to_string()
     }

--- a/members/nullnet-server/src/http_server/services.rs
+++ b/members/nullnet-server/src/http_server/services.rs
@@ -13,6 +13,7 @@ struct ReplicaJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     docker_container: Option<String>,
     active_sessions: usize,
+    suspended: bool,
 }
 
 #[derive(Serialize)]
@@ -48,6 +49,7 @@ pub(super) async fn services_handler(
                         port: r.port(),
                         docker_container: r.docker_container().map(String::from),
                         active_sessions: r.clients().len(),
+                        suspended: r.suspended(),
                     })
                     .collect()
             } else {

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -8,7 +8,7 @@ use crate::services::changes::{
 use crate::services::clients::{Client, ClientInfo};
 use crate::services::edge::{Edge, RegisteredEdge};
 use crate::services::input::{ServicesToml, StackMap};
-use crate::services::service_info::ServiceInfo;
+use crate::services::service_info::{ServiceInfo, backend_involved_services};
 use crate::timeout::check_timeouts;
 use nullnet_grpc_lib::nullnet_grpc::nullnet_grpc_server::NullnetGrpc;
 use nullnet_grpc_lib::nullnet_grpc::{
@@ -676,13 +676,16 @@ impl NullnetGrpcImpl {
 
         // Enforce the invariant: any Docker-backed replica that is idle (e.g. a
         // freshly declared, never-requested container at startup) must be paused.
+        // Backend-involved services are pinned and never paused.
         for stack in service_list_by_stack.keys() {
             let Some(stack_map) = services_mut.get_mut(stack) else {
                 continue;
             };
-            for si in stack_map.values_mut() {
+            let pinned = backend_involved_services(stack_map);
+            for (name, si) in stack_map.iter_mut() {
                 if let ServiceInfo::Registered(reg) = si {
-                    reg.reconcile_suspends(&self.orchestrator).await;
+                    reg.reconcile_suspends(&self.orchestrator, pinned.contains(name))
+                        .await;
                 }
             }
         }
@@ -967,10 +970,16 @@ impl NullnetGrpcImpl {
         if any_failure {
             let mut services_mut = self.services.write().await;
             if let Some(stack_map) = services_mut.get_mut(stack) {
+                let pinned = backend_involved_services(stack_map);
                 for edge in &successful {
                     if let Some(ServiceInfo::Registered(reg)) = stack_map.get_mut(&edge.server_name)
                     {
-                        reg.decrement_chain(&edge.client, &self.orchestrator).await;
+                        reg.decrement_chain(
+                            &edge.client,
+                            &self.orchestrator,
+                            pinned.contains(&edge.server_name),
+                        )
+                        .await;
                     }
                 }
             }

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -352,6 +352,9 @@ impl NullnetGrpcImpl {
             )
             .await?;
 
+        // Suspended replicas are unpaused per-edge inside `net_chain_setup`, so by
+        // the time the chain is built every container in it is already serving.
+
         Ok(Response::new(Upstream {
             ip: upstream_ip.to_string(),
             port: u32::from(service_port),
@@ -671,6 +674,19 @@ impl NullnetGrpcImpl {
             }
         }
 
+        // Enforce the invariant: any Docker-backed replica that is idle (e.g. a
+        // freshly declared, never-requested container at startup) must be paused.
+        for stack in service_list_by_stack.keys() {
+            let Some(stack_map) = services_mut.get_mut(stack) else {
+                continue;
+            };
+            for si in stack_map.values_mut() {
+                if let ServiceInfo::Registered(reg) = si {
+                    reg.reconcile_suspends(&self.orchestrator).await;
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -724,8 +740,46 @@ impl NullnetGrpcImpl {
                     client.clone(),
                     ClientInfo::placeholder(client_ethernet),
                 );
+                // Does the target replica need unpausing before traffic flows?
+                let server_suspended =
+                    reg.replica_suspended(server_ethernet, server_docker.as_deref());
 
                 drop(services_guard);
+
+                // Resume the target container before bringing up the link, so it is
+                // serving by the time traffic arrives. This covers the proxy entry,
+                // proxy dependencies, and every hop of a backend-triggered chain
+                // uniformly (it mirrors the per-edge suspend in `decrement_chain`).
+                if server_suspended && let Some(container) = server_docker.clone() {
+                    if orchestrator
+                        .send_container_resume(server_ethernet, container.clone())
+                        .await
+                    {
+                        if let Some(stack_map) = services.write().await.get_mut(&stack)
+                            && let Some(ServiceInfo::Registered(reg)) =
+                                stack_map.get_mut(server.name())
+                        {
+                            reg.mark_replica_resumed(server_ethernet, server_docker.as_deref());
+                        }
+                    } else {
+                        orchestrator
+                            .events
+                            .emit(Event::container_resume_failed(
+                                container,
+                                format!("no ack from {server_ethernet} within timeout"),
+                            ))
+                            .await;
+                        // roll back the reserved placeholder; the idle replica stays
+                        // suspended (consistent) and the request fails fast.
+                        if let Some(stack_map) = services.write().await.get_mut(&stack)
+                            && let Some(ServiceInfo::Registered(reg)) =
+                                stack_map.get_mut(server.name())
+                        {
+                            reg.remove_client(&client);
+                        }
+                        return EdgeOutcome::Failed;
+                    }
+                }
 
                 let Some(net_id) = orchestrator.allocate_net_id().await else {
                     eprintln!("NET ID pool exhausted");
@@ -1078,6 +1132,12 @@ impl NullnetGrpc for NullnetGrpcImpl {
             }
             AgentEventKind::FirewallRulesLoadFailed(e) => {
                 Event::firewall_rules_load_failed(e.path, e.error_message)
+            }
+            AgentEventKind::ContainerSuspendFailed(e) => {
+                Event::container_suspend_failed(e.docker_container, e.error_message)
+            }
+            AgentEventKind::ContainerResumeFailed(e) => {
+                Event::container_resume_failed(e.docker_container, e.error_message)
             }
             AgentEventKind::VxlanSetupCompleted(e) => {
                 Event::vxlan_setup_completed(e.vxlan_id, e.ns_name)

--- a/members/nullnet-server/src/orchestrator.rs
+++ b/members/nullnet-server/src/orchestrator.rs
@@ -4,7 +4,9 @@ use crate::net::NetExt;
 use crate::net_id_pool::NetIdPool;
 use crate::services::changes::{apply_changes, detect_node_disconnect_changes};
 use crate::services::input::StackMap;
-use nullnet_grpc_lib::nullnet_grpc::{MsgId, NetMessage};
+use nullnet_grpc_lib::nullnet_grpc::{
+    ContainerResume, ContainerSuspend, MsgId, NetMessage, net_message,
+};
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
@@ -138,6 +140,59 @@ impl Orchestrator {
         }
     }
 
+    /// Fire-and-forget: tell the host running `docker_container` to `docker pause` it.
+    /// Mirrors `send_net_teardown` — no ack; the caller marks the replica suspended.
+    pub(crate) async fn send_container_suspend(&self, dest: IpAddr, docker_container: String) {
+        let outbound = self.clients.read().await.get(&dest).cloned();
+        if let Some(outbound) = outbound {
+            println!("Suspending container '{docker_container}' on {dest}");
+            let message = NetMessage {
+                message: Some(net_message::Message::ContainerSuspend(ContainerSuspend {
+                    docker_container,
+                })),
+            };
+            let _ = outbound.send(Ok(message)).await.handle_err(location!());
+        }
+    }
+
+    /// Ack'd: tell the host to `docker unpause` `docker_container` and wait until it
+    /// confirms the container is running again. Mirrors `send_net_setup`'s pending-map
+    /// + 30s timeout. Returns `true` once the client acks (service is serving).
+    pub(crate) async fn send_container_resume(
+        &self,
+        dest: IpAddr,
+        docker_container: String,
+    ) -> bool {
+        let outbound = self.clients.read().await.get(&dest).cloned();
+        let Some(outbound) = outbound else {
+            return false;
+        };
+
+        let (tx, rx) = oneshot::channel();
+        let msg_id = Uuid::new_v4().to_string();
+        self.pending.lock().await.insert(msg_id.clone(), tx);
+
+        println!("Resuming container '{docker_container}' on {dest}");
+        let message = NetMessage {
+            message: Some(net_message::Message::ContainerResume(ContainerResume {
+                msg_id: Some(MsgId { id: msg_id.clone() }),
+                docker_container,
+            })),
+        };
+
+        if outbound.send(Ok(message)).await.is_err() {
+            self.pending.lock().await.remove(&msg_id);
+            return false;
+        }
+
+        if let Ok(result) = tokio::time::timeout(Duration::from_secs(30), rx).await {
+            result.is_ok()
+        } else {
+            self.pending.lock().await.remove(&msg_id);
+            false
+        }
+    }
+
     pub(crate) async fn allocate_net_id(&self) -> Option<u32> {
         self.net_id_pool.lock().await.allocate()
     }
@@ -179,31 +234,48 @@ impl Orchestrator {
     }
 
     pub(crate) async fn register_fake_client(&self, ip: IpAddr) {
+        self.register_recording_client(ip).await;
+    }
+
+    /// Like `register_fake_client`, but returns a log of every `NetMessage` sent
+    /// to the client so tests can assert suspend/resume commands were issued.
+    pub(crate) async fn register_recording_client(
+        &self,
+        ip: IpAddr,
+    ) -> Arc<Mutex<Vec<NetMessage>>> {
         use nullnet_grpc_lib::nullnet_grpc::net_message;
 
+        let log = Arc::new(Mutex::new(Vec::new()));
         let (tx, mut rx) = mpsc::channel::<Result<NetMessage, Status>>(64);
         self.clients.write().await.insert(ip, tx);
 
         let pending = self.pending.clone();
+        let log_task = log.clone();
         tokio::spawn(async move {
             while let Some(Ok(msg)) = rx.recv().await {
-                // auto-ack NetSetup messages
-                match msg.message {
+                // Record before acking so a caller blocked on the ack (resume)
+                // is guaranteed to observe the message once it unblocks.
+                let ack_id = match &msg.message {
                     Some(net_message::Message::VlanSetup(
                         nullnet_grpc_lib::nullnet_grpc::VlanSetup { msg_id, .. },
                     ))
                     | Some(net_message::Message::VxlanSetup(
                         nullnet_grpc_lib::nullnet_grpc::VxlanSetup { msg_id, .. },
-                    )) => {
-                        if let Some(msg_id) = msg_id {
-                            if let Some(tx) = pending.lock().await.remove(&msg_id.id) {
-                                let _ = tx.send(());
-                            }
-                        }
-                    }
-                    _ => {}
+                    ))
+                    | Some(net_message::Message::ContainerResume(ContainerResume {
+                        msg_id, ..
+                    })) => msg_id.clone(),
+                    _ => None,
+                };
+                log_task.lock().await.push(msg);
+                if let Some(msg_id) = ack_id
+                    && let Some(tx) = pending.lock().await.remove(&msg_id.id)
+                {
+                    let _ = tx.send(());
                 }
             }
         });
+
+        log
     }
 }

--- a/members/nullnet-server/src/services/changes.rs
+++ b/members/nullnet-server/src/services/changes.rs
@@ -1,7 +1,7 @@
 use crate::events::Event;
 use crate::orchestrator::Orchestrator;
 use crate::services::clients::Client;
-use crate::services::service_info::ServiceInfo;
+use crate::services::service_info::{ServiceInfo, backend_involved_services};
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::time::Duration;
@@ -432,9 +432,12 @@ async fn teardown_backend_chain(
         only_through,
         services,
     );
+    let pinned = backend_involved_services(services);
     for (client, dep_name) in edges {
         if let Some(ServiceInfo::Registered(dep_reg)) = services.get_mut(&dep_name) {
-            dep_reg.decrement_chain(&client, orchestrator).await;
+            dep_reg
+                .decrement_chain(&client, orchestrator, pinned.contains(&dep_name))
+                .await;
         }
     }
 }
@@ -502,9 +505,12 @@ async fn teardown_dep_chain(
     orchestrator: &Orchestrator,
 ) {
     let edges = collect_dep_chain_edges(service_name, replica_ip, replica_docker, services);
+    let pinned = backend_involved_services(services);
     for (client, dep_name) in edges {
         if let Some(ServiceInfo::Registered(dep_reg)) = services.get_mut(&dep_name) {
-            dep_reg.decrement_chain(&client, orchestrator).await;
+            dep_reg
+                .decrement_chain(&client, orchestrator, pinned.contains(&dep_name))
+                .await;
         }
     }
 }

--- a/members/nullnet-server/src/services/service_info.rs
+++ b/members/nullnet-server/src/services/service_info.rs
@@ -2,9 +2,31 @@ use crate::orchestrator::Orchestrator;
 use crate::services::clients::{Client, ClientInfo, Clients};
 use crate::services::edge::Edge;
 use nullnet_grpc_lib::nullnet_grpc::Upstream;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::{Duration, Instant};
+
+/// Service names that participate in backend trigger chains: those that declare
+/// triggers ("have backend deps") and every service named in a trigger chain
+/// ("is a backend dep"). These are never paused — backend-dep networks aren't
+/// torn down on idle (see `decrement_chain`), so pausing them would strand their
+/// networks and leave the replica unreachable.
+pub(crate) fn backend_involved_services(
+    services: &HashMap<String, ServiceInfo>,
+) -> HashSet<String> {
+    let mut pinned = HashSet::new();
+    for (name, info) in services {
+        let triggers = info.triggers();
+        if triggers.is_empty() {
+            continue;
+        }
+        pinned.insert(name.clone());
+        for dep in triggers.values().flatten() {
+            pinned.insert(dep.clone());
+        }
+    }
+    pinned
+}
 
 #[derive(Clone, Debug)]
 pub(crate) enum ServiceInfo {
@@ -186,7 +208,9 @@ pub(crate) struct Replica {
     docker_container: Option<String>,
     clients: Clients,
     /// Whether the backing Docker container is currently paused. Invariant for
-    /// Docker-backed replicas: `suspended ⟺ clients is empty`.
+    /// non-pinned Docker-backed replicas: `suspended ⟺ clients is empty`
+    /// (backend-involved services are pinned and never paused — see
+    /// [`backend_involved_services`]).
     suspended: bool,
 }
 
@@ -227,10 +251,11 @@ impl Replica {
     }
 
     /// Pause this replica's Docker container when it is Docker-backed, has no
-    /// clients, and isn't already suspended. Fire-and-forget; flips the flag so
-    /// the invariant `suspended ⟺ no clients` holds.
-    async fn reconcile_suspend(&mut self, orchestrator: &Orchestrator) {
-        if self.suspended || !self.clients.clients().is_empty() {
+    /// clients, isn't already suspended, and the service isn't `pinned`
+    /// (backend-involved — see [`backend_involved_services`]). Fire-and-forget;
+    /// flips the flag so the invariant `suspended ⟺ no clients` holds.
+    async fn reconcile_suspend(&mut self, orchestrator: &Orchestrator, pinned: bool) {
+        if pinned || self.suspended || !self.clients.clients().is_empty() {
             return;
         }
         let Some(container) = self.docker_container.clone() else {
@@ -326,7 +351,12 @@ impl RegisteredServiceInfo {
 
     /// Decrement `active_chains` for a specific client entry.
     /// If it reaches 0, the VXLAN is torn down and the entry is removed.
-    pub(crate) async fn decrement_chain(&mut self, client: &Client, orchestrator: &Orchestrator) {
+    pub(crate) async fn decrement_chain(
+        &mut self,
+        client: &Client,
+        orchestrator: &Orchestrator,
+        pinned: bool,
+    ) {
         for replica in &mut self.replicas {
             if let Some(ci) = replica.clients.clients_mut().get_mut(client) {
                 ci.remove_active_chains(1);
@@ -342,8 +372,8 @@ impl RegisteredServiceInfo {
                             ci.net_id(),
                         )
                         .await;
-                    // Invariant: a Docker-backed replica with no clients is paused.
-                    replica.reconcile_suspend(orchestrator).await;
+                    // Invariant: a non-pinned Docker-backed replica with no clients is paused.
+                    replica.reconcile_suspend(orchestrator, pinned).await;
                 }
                 return;
             }
@@ -353,9 +383,9 @@ impl RegisteredServiceInfo {
     /// Pause every Docker-backed replica that is idle and not yet suspended.
     /// Used as the registration-time and periodic safety net that enforces the
     /// invariant for replicas missed by the per-event hooks.
-    pub(crate) async fn reconcile_suspends(&mut self, orchestrator: &Orchestrator) {
+    pub(crate) async fn reconcile_suspends(&mut self, orchestrator: &Orchestrator, pinned: bool) {
         for replica in &mut self.replicas {
-            replica.reconcile_suspend(orchestrator).await;
+            replica.reconcile_suspend(orchestrator, pinned).await;
         }
     }
 

--- a/members/nullnet-server/src/services/service_info.rs
+++ b/members/nullnet-server/src/services/service_info.rs
@@ -185,6 +185,9 @@ pub(crate) struct Replica {
     port: u16,
     docker_container: Option<String>,
     clients: Clients,
+    /// Whether the backing Docker container is currently paused. Invariant for
+    /// Docker-backed replicas: `suspended ⟺ clients is empty`.
+    suspended: bool,
 }
 
 impl Replica {
@@ -194,6 +197,7 @@ impl Replica {
             port,
             docker_container,
             clients: Clients::default(),
+            suspended: false,
         }
     }
 
@@ -216,6 +220,26 @@ impl Replica {
     /// A replica is uniquely identified by its `(ip, docker_container)` pair.
     pub(crate) fn matches_identity(&self, ip: IpAddr, docker_container: Option<&str>) -> bool {
         self.ip == ip && self.docker_container.as_deref() == docker_container
+    }
+
+    pub(crate) fn suspended(&self) -> bool {
+        self.suspended
+    }
+
+    /// Pause this replica's Docker container when it is Docker-backed, has no
+    /// clients, and isn't already suspended. Fire-and-forget; flips the flag so
+    /// the invariant `suspended ⟺ no clients` holds.
+    async fn reconcile_suspend(&mut self, orchestrator: &Orchestrator) {
+        if self.suspended || !self.clients.clients().is_empty() {
+            return;
+        }
+        let Some(container) = self.docker_container.clone() else {
+            return;
+        };
+        orchestrator
+            .send_container_suspend(self.ip, container)
+            .await;
+        self.suspended = true;
     }
 }
 
@@ -318,9 +342,39 @@ impl RegisteredServiceInfo {
                             ci.net_id(),
                         )
                         .await;
+                    // Invariant: a Docker-backed replica with no clients is paused.
+                    replica.reconcile_suspend(orchestrator).await;
                 }
                 return;
             }
+        }
+    }
+
+    /// Pause every Docker-backed replica that is idle and not yet suspended.
+    /// Used as the registration-time and periodic safety net that enforces the
+    /// invariant for replicas missed by the per-event hooks.
+    pub(crate) async fn reconcile_suspends(&mut self, orchestrator: &Orchestrator) {
+        for replica in &mut self.replicas {
+            replica.reconcile_suspend(orchestrator).await;
+        }
+    }
+
+    /// Whether the replica identified by `(ip, docker)` is currently suspended.
+    pub(crate) fn replica_suspended(&self, ip: IpAddr, docker: Option<&str>) -> bool {
+        self.replicas
+            .iter()
+            .find(|r| r.matches_identity(ip, docker))
+            .is_some_and(Replica::suspended)
+    }
+
+    /// Clear the suspended flag for `(ip, docker)` after a successful unpause.
+    pub(crate) fn mark_replica_resumed(&mut self, ip: IpAddr, docker: Option<&str>) {
+        if let Some(replica) = self
+            .replicas
+            .iter_mut()
+            .find(|r| r.matches_identity(ip, docker))
+        {
+            replica.suspended = false;
         }
     }
 

--- a/members/nullnet-server/src/tests.rs
+++ b/members/nullnet-server/src/tests.rs
@@ -2817,6 +2817,71 @@ async fn docker_replica_suspended_on_registration() {
     assert_eq!(total_suspends(&log.lock().await), 1);
 }
 
+/// Services that participate in backend trigger chains are pinned: the
+/// initiator ("has backend deps") and the dep ("is a backend dep") are never
+/// paused, even idle and Docker-backed, because backend-dep networks aren't
+/// torn down on idle. A plain Docker replica in the same list is still paused.
+#[tokio::test]
+async fn backend_involved_replicas_never_suspended() {
+    let mut inner = HashMap::new();
+    // initiator declares a trigger chain → dep (so it "has backend deps")
+    inner.insert(
+        "initiator".to_string(),
+        ServiceInfo::new(
+            vec![],
+            HashMap::from([(8080u16, vec!["dep".to_string()])]),
+            Some(30),
+            None,
+        ),
+    );
+    // dep is named in the trigger chain (so it "is a backend dep")
+    inner.insert(
+        "dep".to_string(),
+        ServiceInfo::new(vec![], HashMap::new(), None, None),
+    );
+    // a plain entry-point service with no backend involvement (control)
+    inner.insert(
+        "plain".to_string(),
+        ServiceInfo::new(vec![], HashMap::new(), Some(30), None),
+    );
+    let server = NullnetGrpcImpl::new_for_test(into_stack_map(inner));
+
+    let svc_ip = ip(1, 1, 1, 1);
+    let log = server
+        .orchestrator()
+        .register_recording_client(svc_ip)
+        .await;
+
+    let list = declared_list(vec![
+        ("initiator", 8080, Some("initiator_c1")),
+        ("dep", 9090, Some("dep_c1")),
+        ("plain", 7070, Some("plain_c1")),
+    ]);
+    server
+        .apply_services_list_by_stack(svc_ip, &list)
+        .await
+        .expect("services list apply failed");
+
+    {
+        let guard = server.services().read().await;
+        assert!(!replica_is_suspended(
+            &guard,
+            "initiator",
+            svc_ip,
+            "initiator_c1"
+        ));
+        assert!(!replica_is_suspended(&guard, "dep", svc_ip, "dep_c1"));
+        // control: the unrelated replica is still paused while idle
+        assert!(replica_is_suspended(&guard, "plain", svc_ip, "plain_c1"));
+    }
+
+    // only the plain replica was ever suspended
+    wait_for_log(&log, |l| count_suspends(l, "plain_c1") == 1).await;
+    assert_eq!(count_suspends(&log.lock().await, "initiator_c1"), 0);
+    assert_eq!(count_suspends(&log.lock().await, "dep_c1"), 0);
+    assert_eq!(total_suspends(&log.lock().await), 1);
+}
+
 #[tokio::test]
 async fn proxy_request_resumes_suspended_replica() {
     let server = suspend_test_server();

--- a/members/nullnet-server/src/tests.rs
+++ b/members/nullnet-server/src/tests.rs
@@ -5,6 +5,7 @@ use crate::nullnet_grpc_impl::NullnetGrpcImpl;
 use crate::services::input::{ServicesToml, StackMap, apply_config_update};
 use crate::services::service_info::ServiceInfo;
 use crate::timeout::apply_timeouts;
+use nullnet_grpc_lib::nullnet_grpc::{NetMessage, net_message};
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
 
@@ -2691,4 +2692,166 @@ async fn proxy_branches_remove_A_tears_down_both() {
 
     let guard = server.services().read().await;
     assert!(!stack_view(&guard).contains_key("A"));
+}
+
+// ===========================================================================
+// container suspend/resume: idle Docker-backed replicas are paused on
+// registration (startup invariant); a proxy request resumes the selected
+// replica before returning the upstream. Host replicas are never touched.
+// ===========================================================================
+
+fn count_msgs(
+    log: &[NetMessage],
+    suspend_container: Option<&str>,
+    resume_container: Option<&str>,
+) -> usize {
+    log.iter()
+        .filter(|m| match &m.message {
+            Some(net_message::Message::ContainerSuspend(s)) => {
+                suspend_container.is_some_and(|c| c == s.docker_container)
+            }
+            Some(net_message::Message::ContainerResume(r)) => {
+                resume_container.is_some_and(|c| c == r.docker_container)
+            }
+            _ => false,
+        })
+        .count()
+}
+
+fn count_suspends(log: &[NetMessage], container: &str) -> usize {
+    count_msgs(log, Some(container), None)
+}
+
+fn count_resumes(log: &[NetMessage], container: &str) -> usize {
+    count_msgs(log, None, Some(container))
+}
+
+fn total_suspends(log: &[NetMessage]) -> usize {
+    log.iter()
+        .filter(|m| matches!(&m.message, Some(net_message::Message::ContainerSuspend(_))))
+        .count()
+}
+
+fn replica_is_suspended(guard: &StackMap, service: &str, svc_ip: IpAddr, container: &str) -> bool {
+    match stack_view(guard).get(service) {
+        Some(ServiceInfo::Registered(reg)) => reg.replica_suspended(svc_ip, Some(container)),
+        _ => false,
+    }
+}
+
+/// Poll the recording log until `want` holds. The suspend command is
+/// fire-and-forget (no ack to synchronize on), so we wait for it to drain.
+/// Bounded so a genuine failure still terminates.
+async fn wait_for_log(
+    log: &std::sync::Arc<tokio::sync::Mutex<Vec<NetMessage>>>,
+    want: impl Fn(&[NetMessage]) -> bool,
+) {
+    for _ in 0..200 {
+        if want(&log.lock().await) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    panic!("log condition not met within timeout");
+}
+
+fn suspend_test_server() -> NullnetGrpcImpl {
+    let mut inner = HashMap::new();
+    // both are proxy entry points (timeout = Some); one Docker-backed, one host
+    inner.insert(
+        "svc".to_string(),
+        ServiceInfo::new(vec![], HashMap::new(), Some(30), None),
+    );
+    inner.insert(
+        "host_svc".to_string(),
+        ServiceInfo::new(vec![], HashMap::new(), Some(30), None),
+    );
+    NullnetGrpcImpl::new_for_test(into_stack_map(inner))
+}
+
+fn declared_list(
+    entries: Vec<(&str, u16, Option<&str>)>,
+) -> HashMap<String, Vec<(String, u16, Option<String>)>> {
+    HashMap::from([(
+        TEST_STACK.to_string(),
+        entries
+            .into_iter()
+            .map(|(n, p, d)| (n.to_string(), p, d.map(ToString::to_string)))
+            .collect(),
+    )])
+}
+
+#[tokio::test]
+async fn docker_replica_suspended_on_registration() {
+    let server = suspend_test_server();
+    let svc_ip = ip(1, 1, 1, 1);
+    let log = server
+        .orchestrator()
+        .register_recording_client(svc_ip)
+        .await;
+
+    let list = declared_list(vec![
+        ("svc", 8080, Some("svc_c1")),
+        ("host_svc", 9090, None),
+    ]);
+    server
+        .apply_services_list_by_stack(svc_ip, &list)
+        .await
+        .expect("services list apply failed");
+
+    // the Docker-backed, never-requested replica is paused immediately
+    {
+        let guard = server.services().read().await;
+        assert!(replica_is_suspended(&guard, "svc", svc_ip, "svc_c1"));
+    }
+    // exactly one suspend command was sent, only for the Docker-backed replica
+    wait_for_log(&log, |l| count_suspends(l, "svc_c1") == 1).await;
+    assert_eq!(total_suspends(&log.lock().await), 1);
+
+    // re-declaration (the client's 10s heartbeat) does not re-suspend
+    server
+        .apply_services_list_by_stack(svc_ip, &list)
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+    assert_eq!(total_suspends(&log.lock().await), 1);
+}
+
+#[tokio::test]
+async fn proxy_request_resumes_suspended_replica() {
+    let server = suspend_test_server();
+    let svc_ip = ip(1, 1, 1, 1);
+    let proxy_ip = ip(5, 5, 5, 5);
+    let log = server
+        .orchestrator()
+        .register_recording_client(svc_ip)
+        .await;
+    server.orchestrator().register_fake_client(proxy_ip).await;
+
+    let list = declared_list(vec![("svc", 8080, Some("svc_c1"))]);
+    server
+        .apply_services_list_by_stack(svc_ip, &list)
+        .await
+        .unwrap();
+
+    // precondition: suspended after registration
+    {
+        let guard = server.services().read().await;
+        assert!(replica_is_suspended(&guard, "svc", svc_ip, "svc_c1"));
+    }
+
+    // a proxy request resumes it before returning the upstream
+    server
+        .handle_proxy_request("svc", proxy_ip, "10.0.0.1")
+        .await
+        .expect("proxy request failed");
+
+    {
+        let guard = server.services().read().await;
+        assert!(
+            !replica_is_suspended(&guard, "svc", svc_ip, "svc_c1"),
+            "replica should be resumed once a client is attached"
+        );
+    }
+    assert_eq!(count_resumes(&log.lock().await, "svc_c1"), 1);
 }

--- a/members/nullnet-server/src/timeout.rs
+++ b/members/nullnet-server/src/timeout.rs
@@ -2,7 +2,7 @@ use crate::env::TIMEOUT;
 use crate::orchestrator::Orchestrator;
 use crate::services::changes::{ServiceChange, apply_changes};
 use crate::services::input::StackMap;
-use crate::services::service_info::ServiceInfo;
+use crate::services::service_info::{ServiceInfo, backend_involved_services};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -51,10 +51,13 @@ pub(crate) async fn apply_timeouts(
     // Safety net: enforce the invariant that every idle Docker-backed replica is
     // paused, catching any missed by the per-event hooks (startup, races,
     // restarts). Cheap when nothing is pending — `reconcile_suspends` skips
-    // replicas that are already suspended or still have clients.
-    for si in services.values_mut() {
+    // replicas that are already suspended or still have clients. Backend-involved
+    // services are pinned and never paused.
+    let pinned = backend_involved_services(services);
+    for (name, si) in services.iter_mut() {
         if let ServiceInfo::Registered(reg) = si {
-            reg.reconcile_suspends(orchestrator).await;
+            reg.reconcile_suspends(orchestrator, pinned.contains(name))
+                .await;
         }
     }
 }

--- a/members/nullnet-server/src/timeout.rs
+++ b/members/nullnet-server/src/timeout.rs
@@ -47,6 +47,16 @@ pub(crate) async fn apply_timeouts(
     if !changes.is_empty() {
         apply_changes(changes, services, None, orchestrator, stack).await;
     }
+
+    // Safety net: enforce the invariant that every idle Docker-backed replica is
+    // paused, catching any missed by the per-event hooks (startup, races,
+    // restarts). Cheap when nothing is pending — `reconcile_suspends` skips
+    // replicas that are already suspended or still have clients.
+    for si in services.values_mut() {
+        if let ServiceInfo::Registered(reg) = si {
+            reg.reconcile_suspends(orchestrator).await;
+        }
+    }
 }
 
 fn collect_timed_out_clients(services: &HashMap<String, ServiceInfo>) -> Vec<ServiceChange> {

--- a/members/nullnet-server/tests/fixtures/backend_multi_replica/after_disconnect_standalone_dep.dot
+++ b/members/nullnet-server/tests/fixtures/backend_multi_replica/after_disconnect_standalone_dep.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (2/2)"] [style=dashed, color=green];
+	"B" [label="B\n2 active / 0 paused / 2 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 	"E" -> "B" [label="VXLAN 103 [0ms]"];
 
-	"D" [label="D (0/1)"] [style=solid, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"E" [label="E (1/1)"] [style=solid, color=green];
+	"E" [label="E\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_multi_replica/after_disconnect_standalone_dep.dot
+++ b/members/nullnet-server/tests/fixtures/backend_multi_replica/after_disconnect_standalone_dep.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n2 active / 0 paused / 2 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 	"E" -> "B" [label="VXLAN 103 [0ms]"];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"E" [label="E\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"E" [label=<E<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_multi_replica/after_disconnect_swarm_host.dot
+++ b/members/nullnet-server/tests/fixtures/backend_multi_replica/after_disconnect_swarm_host.dot
@@ -3,12 +3,12 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "B" [label="VXLAN 102 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"E" [label="E (0/1)"] [style=solid, color=green];
+	"E" [label="E\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_multi_replica/after_disconnect_swarm_host.dot
+++ b/members/nullnet-server/tests/fixtures/backend_multi_replica/after_disconnect_swarm_host.dot
@@ -3,12 +3,12 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "B" [label="VXLAN 102 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"E" [label="E\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"E" [label=<E<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_multi_replica/start.dot
+++ b/members/nullnet-server/tests/fixtures/backend_multi_replica/start.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (3/3)"] [style=dashed, color=green];
+	"B" [label="B\n3 active / 0 paused / 3 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 	"D" -> "B" [label="VXLAN 102 [0ms]"];
 	"E" -> "B" [label="VXLAN 103 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"E" [label="E (1/1)"] [style=solid, color=green];
+	"E" [label="E\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_multi_replica/start.dot
+++ b/members/nullnet-server/tests/fixtures/backend_multi_replica/start.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n3 active / 0 paused / 3 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">3 active / 0 paused / 3 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 	"D" -> "B" [label="VXLAN 102 [0ms]"];
 	"E" -> "B" [label="VXLAN 103 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"E" [label="E\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"E" [label=<E<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_backend_dep.dot
+++ b/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_backend_dep.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/2)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 2 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
 	"C" [label="C"] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_backend_dep.dot
+++ b/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_backend_dep.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"C" [label="C"] [style=dashed, color=red];
+	"C" [label=<C>] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_initiator.dot
+++ b/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_initiator.dot
@@ -5,7 +5,7 @@ digraph G {
 
 	"A" [label="A"] [style=solid, color=red];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_initiator.dot
+++ b/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_initiator.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A"] [style=solid, color=red];
+	"A" [label=<A>] [style=solid, color=red];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_proxy.dot
+++ b/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_proxy.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 	"A" -> "C" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_proxy.dot
+++ b/members/nullnet-server/tests/fixtures/backend_node_disconnected/after_disconnect_proxy.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (2/2)"] [style=solid, color=green];
+	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 	"A" -> "C" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_node_disconnected/start.dot
+++ b/members/nullnet-server/tests/fixtures/backend_node_disconnected/start.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (2/2)"] [style=solid, color=green];
+	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
-	"A" -> "C" [label="VXLAN 104 [0ms]"];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
+	"A" -> "C" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_node_disconnected/start.dot
+++ b/members/nullnet-server/tests/fixtures/backend_node_disconnected/start.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 	"A" -> "C" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_reachability_changed/after_lose_entry_point_A.dot
+++ b/members/nullnet-server/tests/fixtures/backend_reachability_changed/after_lose_entry_point_A.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=dashed, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"Z" [label="Z (0/1)"] [style=solid, color=green];
+	"Z" [label="Z\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_reachability_changed/after_lose_entry_point_A.dot
+++ b/members/nullnet-server/tests/fixtures/backend_reachability_changed/after_lose_entry_point_A.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"Z" [label="Z\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"Z" [label=<Z<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_reachability_changed/start.dot
+++ b/members/nullnet-server/tests/fixtures/backend_reachability_changed/start.dot
@@ -3,10 +3,10 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"Z" [label="Z (0/1)"] [style=solid, color=green];
+	"Z" [label="Z\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_reachability_changed/start.dot
+++ b/members/nullnet-server/tests/fixtures/backend_reachability_changed/start.dot
@@ -3,10 +3,10 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"Z" [label="Z\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"Z" [label=<Z<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_B.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_B.dot
@@ -3,7 +3,7 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n2 active / 2 paused / 2 total"] [style=solid, color=green];
+	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
 
 	"B" [label="B"] [style=dashed, color=red];
 

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_B.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_B.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B"] [style=dashed, color=red];
+	"B" [label=<B>] [style=dashed, color=red];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
-	"A" -> "C" [label="VXLAN 103 [0ms]"];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 104 [0ms]"];
+	"A" -> "C" [label="VXLAN 103 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_B.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_B.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (2/2)"] [style=solid, color=green];
+	"A" [label="A\n2 active / 2 paused / 2 total"] [style=solid, color=green];
 
 	"B" [label="B"] [style=dashed, color=red];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 	"A" -> "C" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_C.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_C.dot
@@ -3,7 +3,7 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 2 paused / 2 total"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 2 total"] [style=solid, color=green];
 
 	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_C.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_C.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/2)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 2 paused / 2 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
 	"C" [label="C"] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_C.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_C.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"C" [label="C"] [style=dashed, color=red];
+	"C" [label=<C>] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_a2.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_a2.dot
@@ -3,12 +3,12 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_a2.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/after_drop_a2.dot
@@ -3,12 +3,12 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/start.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/start.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 	"A" -> "C" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/backend_service_unregistered/start.dot
+++ b/members/nullnet-server/tests/fixtures/backend_service_unregistered/start.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (2/2)"] [style=solid, color=green];
+	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 	"A" -> "C" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/dep_changed/after_add_E_to_A.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/after_add_E_to_A.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "D" [label="VXLAN 105 [0ms]"];
 
 	"E" [label="E"] [style=dashed, color=red];

--- a/members/nullnet-server/tests/fixtures/dep_changed/after_add_E_to_A.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/after_add_E_to_A.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "D" [label="VXLAN 105 [0ms]"];
 
-	"E" [label="E"] [style=dashed, color=red];
+	"E" [label=<E>] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/dep_changed/after_drop_C_from_A.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/after_drop_C_from_A.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "D" [label="VXLAN 105 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/dep_changed/after_drop_C_from_A.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/after_drop_C_from_A.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "D" [label="VXLAN 105 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/dep_changed/after_drop_all_from_D.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/after_drop_all_from_D.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 
-	"D" [label="D (0/1)"] [style=solid, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/dep_changed/after_drop_all_from_D.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/after_drop_all_from_D.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/dep_changed/after_swap_C_for_E.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/after_swap_C_for_E.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "D" [label="VXLAN 105 [0ms]"];
 
 	"E" [label="E"] [style=dashed, color=red];

--- a/members/nullnet-server/tests/fixtures/dep_changed/after_swap_C_for_E.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/after_swap_C_for_E.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "D" [label="VXLAN 105 [0ms]"];
 
-	"E" [label="E"] [style=dashed, color=red];
+	"E" [label=<E>] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/dep_changed/start.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "D" [label="VXLAN 105 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/dep_changed/start.dot
+++ b/members/nullnet-server/tests/fixtures/dep_changed/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "D" [label="VXLAN 105 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_first_client.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_first_client.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_first_client.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_first_client.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_first_timeout.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_first_timeout.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_first_timeout.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_first_timeout.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_proxy1_client.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_proxy1_client.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_proxy1_client.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_proxy1_client.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
-	"A" -> "B" [label="VXLAN 101 [1ms]"];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_proxy2_bypasses.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_proxy2_bypasses.dot
@@ -3,10 +3,10 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 103 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_proxy2_bypasses.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_proxy2_bypasses.dot
@@ -3,10 +3,10 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 103 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
-	"A" -> "B" [label="VXLAN 101 [1ms]"];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_proxy_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_proxy_disconnect.dot
@@ -3,7 +3,7 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_proxy_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_proxy_disconnect.dot
@@ -3,7 +3,7 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_reuse.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_reuse.dot
@@ -3,10 +3,10 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.2 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_reuse.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_reuse.dot
@@ -3,10 +3,10 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.2 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_second_timeout.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_second_timeout.dot
@@ -3,7 +3,7 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=dashed, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/after_second_timeout.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/after_second_timeout.dot
@@ -3,7 +3,7 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/before_proxy_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/before_proxy_disconnect.dot
@@ -3,10 +3,10 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.2 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/max_networks/before_proxy_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/max_networks/before_proxy_disconnect.dot
@@ -3,10 +3,10 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.2 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_b_different_ip_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_b_different_ip_disconnect.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (2/2)"] [style=solid, color=green];
+	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.4 (via 7.7.7.7)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (2/2)"] [style=dashed, color=green];
+	"B" [label="B\n2 active / 0 paused / 2 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 	"A" -> "B" [label="VXLAN 105 [0ms]"];
 	"D" -> "B" [label="VXLAN 107 [0ms]"];
 
-	"C" [label="C (0/1)"] [style=solid, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.3 (via 5.5.5.5)" -> "D" [label="VXLAN 108 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_b_different_ip_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_b_different_ip_disconnect.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.4 (via 7.7.7.7)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n2 active / 0 paused / 2 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 	"A" -> "B" [label="VXLAN 105 [0ms]"];
 	"D" -> "B" [label="VXLAN 107 [0ms]"];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.3 (via 5.5.5.5)" -> "D" [label="VXLAN 108 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_b_same_ip_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_b_same_ip_disconnect.dot
@@ -3,16 +3,16 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/2)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 1 paused / 2 total"] [style=solid, color=green];
 	"10.0.0.4 (via 7.7.7.7)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (2/2)"] [style=dashed, color=green];
+	"B" [label="B\n2 active / 0 paused / 2 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 105 [0ms]"];
 	"C" -> "B" [label="VXLAN 103 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=solid, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "C" [label="VXLAN 104 [0ms]"];
 	"10.0.0.5 (via 7.7.7.7)" -> "C" [label="VXLAN 109 [0ms]"];
 
-	"D" [label="D (0/1)"] [style=solid, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_b_same_ip_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_b_same_ip_disconnect.dot
@@ -3,16 +3,16 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 1 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 1 paused / 2 total</FONT>>] [style=solid, color=green];
 	"10.0.0.4 (via 7.7.7.7)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n2 active / 0 paused / 2 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 105 [0ms]"];
 	"C" -> "B" [label="VXLAN 103 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "C" [label="VXLAN 104 [0ms]"];
 	"10.0.0.5 (via 7.7.7.7)" -> "C" [label="VXLAN 109 [0ms]"];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_first_step_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_first_step_disconnect.dot
@@ -3,18 +3,18 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.4 (via 7.7.7.7)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n3 active / 0 paused / 3 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">3 active / 0 paused / 3 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 105 [0ms]"];
 	"C" -> "B" [label="VXLAN 103 [0ms]"];
 	"D" -> "B" [label="VXLAN 107 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "C" [label="VXLAN 104 [0ms]"];
 	"10.0.0.5 (via 7.7.7.7)" -> "C" [label="VXLAN 109 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.3 (via 5.5.5.5)" -> "D" [label="VXLAN 108 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_first_step_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_first_step_disconnect.dot
@@ -3,18 +3,18 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.4 (via 7.7.7.7)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (3/3)"] [style=dashed, color=green];
+	"B" [label="B\n3 active / 0 paused / 3 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 105 [0ms]"];
 	"C" -> "B" [label="VXLAN 103 [0ms]"];
 	"D" -> "B" [label="VXLAN 107 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=solid, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "C" [label="VXLAN 104 [0ms]"];
 	"10.0.0.5 (via 7.7.7.7)" -> "C" [label="VXLAN 109 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.3 (via 5.5.5.5)" -> "D" [label="VXLAN 108 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_full_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_full_disconnect.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/2)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 2 total"] [style=solid, color=green];
 
 	"B" [label="B"] [style=dashed, color=red];
 
-	"C" [label="C (0/1)"] [style=solid, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"D" [label="D (0/1)"] [style=solid, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_full_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_full_disconnect.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B"] [style=dashed, color=red];
+	"B" [label=<B>] [style=dashed, color=red];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_partial_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_partial_disconnect.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"C" -> "B" [label="VXLAN 103 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/after_partial_disconnect.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/after_partial_disconnect.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/2)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 2 total"] [style=solid, color=green];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"C" -> "B" [label="VXLAN 103 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=solid, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (0/1)"] [style=solid, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/start.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/start.dot
@@ -3,20 +3,20 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">2 active / 0 paused / 2 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.4 (via 7.7.7.7)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n3 active / 0 paused / 3 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">3 active / 0 paused / 3 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 	"A" -> "B" [label="VXLAN 105 [0ms]"];
 	"C" -> "B" [label="VXLAN 103 [0ms]"];
 	"D" -> "B" [label="VXLAN 107 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "C" [label="VXLAN 104 [0ms]"];
 	"10.0.0.5 (via 7.7.7.7)" -> "C" [label="VXLAN 109 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.3 (via 5.5.5.5)" -> "D" [label="VXLAN 108 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/multi_replica/start.dot
+++ b/members/nullnet-server/tests/fixtures/multi_replica/start.dot
@@ -3,20 +3,20 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (2/2)"] [style=solid, color=green];
+	"A" [label="A\n2 active / 0 paused / 2 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 	"10.0.0.4 (via 7.7.7.7)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (3/3)"] [style=dashed, color=green];
+	"B" [label="B\n3 active / 0 paused / 3 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 	"A" -> "B" [label="VXLAN 105 [0ms]"];
 	"C" -> "B" [label="VXLAN 103 [0ms]"];
 	"D" -> "B" [label="VXLAN 107 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=solid, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.2 (via 5.5.5.5)" -> "C" [label="VXLAN 104 [0ms]"];
 	"10.0.0.5 (via 7.7.7.7)" -> "C" [label="VXLAN 109 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.3 (via 5.5.5.5)" -> "D" [label="VXLAN 108 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_A_B.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_A_B.dot
@@ -7,7 +7,7 @@ digraph G {
 
 	"B" [label="B"] [style=solid, color=red];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"D" [label="D (0/1)"] [style=dashed, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_A_B.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_A_B.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A"] [style=solid, color=red];
+	"A" [label=<A>] [style=solid, color=red];
 
-	"B" [label="B"] [style=solid, color=red];
+	"B" [label=<B>] [style=solid, color=red];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_C.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_C.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
 	"C" [label="C"] [style=dashed, color=red];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_C.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_C.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C"] [style=dashed, color=red];
+	"C" [label=<C>] [style=dashed, color=red];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_D.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_D.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"D" [label="D"] [style=dashed, color=red];
+	"D" [label=<D>] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_D.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_D.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=solid, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
 	"D" [label="D"] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_proxy1.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_proxy1.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (0/1)"] [style=solid, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_proxy1.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/after_disconnect_proxy1.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/start.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/node_disconnected/start.dot
+++ b/members/nullnet-server/tests/fixtures/node_disconnected/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
-	"A" -> "C" [label="VXLAN 101 [1ms]"];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_config_remove_timeout_A.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_config_remove_timeout_A.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
-	"B" -> "D" [label="VXLAN 104 [2ms]"];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_config_remove_timeout_A.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_config_remove_timeout_A.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_config_tighten_B.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_config_tighten_B.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_config_tighten_B.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_config_tighten_B.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (0/1)"] [style=solid, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_A.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_A.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_A.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_A.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_A_then_B.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_A_then_B.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=solid, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"D" [label="D (0/1)"] [style=dashed, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_A_then_B.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_A_then_B.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_all.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_all.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=solid, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"D" [label="D (0/1)"] [style=dashed, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_all.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/after_timeout_all.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/start.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/proxy_timeout/start.dot
+++ b/members/nullnet-server/tests/fixtures/proxy_timeout/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/reachability_changed/after_unreachable_B.dot
+++ b/members/nullnet-server/tests/fixtures/reachability_changed/after_unreachable_B.dot
@@ -3,18 +3,18 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "A" [label="VXLAN 103 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "D" [label="VXLAN 105 [0ms]"];
 
-	"E" [label="E\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"E" [label=<E<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "E" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/reachability_changed/after_unreachable_B.dot
+++ b/members/nullnet-server/tests/fixtures/reachability_changed/after_unreachable_B.dot
@@ -3,18 +3,18 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "A" [label="VXLAN 103 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "D" [label="VXLAN 105 [0ms]"];
 
-	"E" [label="E (1/1)"] [style=dashed, color=green];
+	"E" [label="E\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "E" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/reachability_changed/after_unreachable_D.dot
+++ b/members/nullnet-server/tests/fixtures/reachability_changed/after_unreachable_D.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "A" [label="VXLAN 103 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.2 (via 7.7.7.7)" -> "B" [label="VXLAN 106 [0ms]"];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/reachability_changed/after_unreachable_D.dot
+++ b/members/nullnet-server/tests/fixtures/reachability_changed/after_unreachable_D.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "A" [label="VXLAN 103 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.2 (via 7.7.7.7)" -> "B" [label="VXLAN 106 [0ms]"];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/reachability_changed/start.dot
+++ b/members/nullnet-server/tests/fixtures/reachability_changed/start.dot
@@ -3,19 +3,19 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "A" [label="VXLAN 103 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.2 (via 7.7.7.7)" -> "B" [label="VXLAN 106 [0ms]"];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "D" [label="VXLAN 105 [0ms]"];
 
-	"E" [label="E\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"E" [label=<E<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "E" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/reachability_changed/start.dot
+++ b/members/nullnet-server/tests/fixtures/reachability_changed/start.dot
@@ -3,19 +3,19 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "A" [label="VXLAN 103 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.2 (via 7.7.7.7)" -> "B" [label="VXLAN 106 [0ms]"];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "C" [label="VXLAN 102 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 6.6.6.6)" -> "D" [label="VXLAN 105 [0ms]"];
 
-	"E" [label="E (1/1)"] [style=dashed, color=green];
+	"E" [label="E\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "E" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_removed/after_remove_A.dot
+++ b/members/nullnet-server/tests/fixtures/service_removed/after_remove_A.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_removed/after_remove_A.dot
+++ b/members/nullnet-server/tests/fixtures/service_removed/after_remove_A.dot
@@ -3,9 +3,9 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_removed/after_remove_B.dot
+++ b/members/nullnet-server/tests/fixtures/service_removed/after_remove_B.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_removed/after_remove_B.dot
+++ b/members/nullnet-server/tests/fixtures/service_removed/after_remove_B.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_removed/start.dot
+++ b/members/nullnet-server/tests/fixtures/service_removed/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_removed/start.dot
+++ b/members/nullnet-server/tests/fixtures/service_removed/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_A.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_A.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A"] [style=solid, color=red];
+	"A" [label=<A>] [style=solid, color=red];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_A.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_A.dot
@@ -5,11 +5,11 @@ digraph G {
 
 	"A" [label="A"] [style=solid, color=red];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_B.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_B.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B"] [style=solid, color=red];
+	"B" [label=<B>] [style=solid, color=red];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_B.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_B.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
 	"B" [label="B"] [style=solid, color=red];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_C.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_C.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
 	"C" [label="C"] [style=dashed, color=red];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_C.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_C.dot
@@ -3,13 +3,13 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C"] [style=dashed, color=red];
+	"C" [label=<C>] [style=dashed, color=red];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_D.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_D.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 
-	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 
-	"D" [label="D"] [style=dashed, color=red];
+	"D" [label=<D>] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_D.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/after_drop_D.dot
@@ -3,11 +3,11 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (0/1)"] [style=solid, color=green];
+	"A" [label="A\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"B" [label="B (0/1)"] [style=solid, color=green];
+	"B" [label="B\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 
-	"C" [label="C (0/1)"] [style=dashed, color=green];
+	"C" [label="C\n0 active / 0 paused / 1 total"] [style=dashed, color=green];
 
 	"D" [label="D"] [style=dashed, color=red];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/start.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/service_unregistered/start.dot
+++ b/members/nullnet-server/tests/fixtures/service_unregistered/start.dot
@@ -3,17 +3,17 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 103 [0ms]"];
 	"10.0.0.2 (via 6.6.6.6)" -> "A" [label="VXLAN 106 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=solid, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "B" [label="VXLAN 105 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 101 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=dashed, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"B" -> "D" [label="VXLAN 104 [0ms]"];
 	"C" -> "D" [label="VXLAN 102 [0ms]"];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/after_add_A_trigger.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/after_add_A_trigger.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/after_add_A_trigger.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/after_add_A_trigger.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/after_drop_D_trigger.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/after_drop_D_trigger.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 
-	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">0 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/after_drop_D_trigger.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/after_drop_D_trigger.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 
-	"D" [label="D (0/1)"] [style=solid, color=green];
+	"D" [label="D\n0 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/after_remove_A_trigger.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/after_remove_A_trigger.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/after_remove_A_trigger.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/after_remove_A_trigger.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/after_swap_A_trigger.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/after_swap_A_trigger.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/after_swap_A_trigger.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/after_swap_A_trigger.dot
@@ -3,14 +3,14 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/start.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/start.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A (1/1)"] [style=solid, color=green];
+	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B (1/1)"] [style=dashed, color=green];
+	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C (1/1)"] [style=dashed, color=green];
+	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D (1/1)"] [style=solid, color=green];
+	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
 }

--- a/members/nullnet-server/tests/fixtures/triggers_changed/start.dot
+++ b/members/nullnet-server/tests/fixtures/triggers_changed/start.dot
@@ -3,15 +3,15 @@ digraph G {
 	node [color=white, fontcolor=white];
 	edge [color=white, fontcolor=white, fontsize=9, labelangle=180, labeldistance=0.8];
 
-	"A" [label="A\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"A" [label=<A<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 	"10.0.0.1 (via 5.5.5.5)" -> "A" [label="VXLAN 102 [0ms]"];
 
-	"B" [label="B\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"B" [label=<B<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "B" [label="VXLAN 101 [0ms]"];
 
-	"C" [label="C\n1 active / 0 paused / 1 total"] [style=dashed, color=green];
+	"C" [label=<C<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=dashed, color=green];
 	"A" -> "C" [label="VXLAN 103 [0ms]"];
 	"D" -> "C" [label="VXLAN 104 [0ms]"];
 
-	"D" [label="D\n1 active / 0 paused / 1 total"] [style=solid, color=green];
+	"D" [label=<D<BR/><FONT POINT-SIZE="9">1 active / 0 paused / 1 total</FONT>>] [style=solid, color=green];
 }

--- a/members/nullnet-server/ui/src/components/topology/ServiceNodePanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/ServiceNodePanel.tsx
@@ -31,7 +31,7 @@ export default function ServiceNodePanel({ node, service, onDepClick }: Props) {
 
       <div style={spRow}>
         <div style={spKey}>Replicas</div>
-        <div style={spVal}>{node.active_replica_count} active / {node.replica_count} total</div>
+        <div style={spVal}>{node.active_replica_count} active / {node.paused_replica_count} paused / {node.replica_count} total</div>
       </div>
 
       {service?.timeout_secs != null && (

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
@@ -269,6 +269,7 @@ export default function TopologyGraphSvg({
               )}
               <text x={p.x + 27} y={p.y + (ip ? 42 : 31)} fill="rgba(255,255,255,.3)" fontSize="7.5">
                 {n.registered ? `${n.active_replica_count}/${n.replica_count} active` : 'unregistered'}
+                {n.registered && n.paused_replica_count > 0 ? ` · ${n.paused_replica_count} paused` : ''}
                 {n.entry_point ? ' · entry' : ''}
               </text>
             </g>

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -43,6 +43,8 @@ const KIND_LABELS: Record<string, string> = {
   services_list_update_failed: 'services_list_update_failed',
   backend_trigger_send_failed: 'backend_trigger_send_failed',
   firewall_rules_load_failed: 'firewall_rules_load_failed',
+  container_suspend_failed: 'container_suspend_failed',
+  container_resume_failed: 'container_resume_failed',
   // Client info
   vxlan_setup_completed: 'vxlan_setup_completed',
   vlan_setup_completed: 'vlan_setup_completed',
@@ -119,6 +121,9 @@ function eventDetail(e: EventJson): string {
       return `${e.service_name} · port ${e.port} · ${e.error_message}`;
     case 'firewall_rules_load_failed':
       return `${e.path} · ${e.error_message}`;
+    case 'container_suspend_failed':
+    case 'container_resume_failed':
+      return `${e.docker_container} · ${e.error_message}`;
     // Client info
     case 'vxlan_setup_completed':
       return `vxlan ${e.vxlan_id} · ${e.ns_name}`;

--- a/members/nullnet-server/ui/src/pages/Services.tsx
+++ b/members/nullnet-server/ui/src/pages/Services.tsx
@@ -71,6 +71,7 @@ export default function Services() {
               {visible.map(svc => {
                 const isOpen = expanded.has(svc.name);
                 const totalSessions = svc.replicas.reduce((n, r) => n + r.active_sessions, 0);
+                const pausedCount = svc.replicas.filter(r => r.suspended).length;
                 return (
                   <>
                     <tr key={svc.name} onClick={() => toggle(svc.name)} style={{ cursor: 'pointer' }}>
@@ -85,6 +86,9 @@ export default function Services() {
                       </td>
                       <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t1)' }}>
                         {svc.replicas.length}
+                        {pausedCount > 0 && (
+                          <span className="badge b-amber" style={{ marginLeft: 6 }}>{pausedCount} paused</span>
+                        )}
                       </td>
                       <td>
                         {svc.proxy_dependencies.flat().length > 0
@@ -108,7 +112,7 @@ export default function Services() {
                                 {svc.replicas.length > 0 ? (
                                   <table className="sub-tbl">
                                     <thead>
-                                      <tr><th>IP</th><th>Port</th><th>Sessions</th>{svc.replicas.some(r => r.docker_container) && <th>Container</th>}</tr>
+                                      <tr><th>IP</th><th>Port</th><th>Sessions</th><th>State</th>{svc.replicas.some(r => r.docker_container) && <th>Container</th>}</tr>
                                     </thead>
                                     <tbody>
                                       {svc.replicas.map((r, i) => (
@@ -116,6 +120,7 @@ export default function Services() {
                                           <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>{r.ip}</td>
                                           <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t1)' }}>:{r.port}</td>
                                           <td style={{ fontFamily: "'JetBrains Mono',monospace", color: r.active_sessions > 0 ? 'var(--green)' : 'var(--t2)' }}>{r.active_sessions}</td>
+                                          <td><span className={`badge ${r.suspended ? 'b-amber' : 'b-green'}`}>{r.suspended ? 'Paused' : 'Running'}</span></td>
                                           {r.docker_container && <td style={{ color: 'var(--t2)', fontSize: 10 }}>{r.docker_container}</td>}
                                         </tr>
                                       ))}

--- a/members/nullnet-server/ui/src/types.ts
+++ b/members/nullnet-server/ui/src/types.ts
@@ -90,6 +90,8 @@ export type EventJson =
   | WithSeverity & { type: 'services_list_update_failed'; error_message: string; num_services: number }
   | WithSeverity & { type: 'backend_trigger_send_failed'; service_name: string; port: number; error_message: string }
   | WithSeverity & { type: 'firewall_rules_load_failed'; path: string; error_message: string }
+  | WithSeverity & { type: 'container_suspend_failed'; docker_container: string; error_message: string }
+  | WithSeverity & { type: 'container_resume_failed'; docker_container: string; error_message: string }
   // Client info events
   | WithSeverity & { type: 'vxlan_setup_completed'; vxlan_id: number; ns_name: string }
   | WithSeverity & { type: 'vlan_setup_completed'; vlan_id: number }

--- a/members/nullnet-server/ui/src/types.ts
+++ b/members/nullnet-server/ui/src/types.ts
@@ -7,6 +7,7 @@ export interface ReplicaJson {
   port: number;
   docker_container?: string;
   active_sessions: number;
+  suspended: boolean;
 }
 
 export interface ServiceJson {
@@ -114,6 +115,7 @@ export interface GraphNodeJson {
   entry_point: boolean;
   replica_count: number;
   active_replica_count: number;
+  paused_replica_count: number;
 }
 
 export interface GraphEdgeJson {


### PR DESCRIPTION
Idle Docker-backed replicas are `docker pause`d and `docker unpause`d on demand.
Backend-trigger services (initiators and their deps) are pinned and never paused, since their networks aren't torn down on idle.
Adds paused-replica counts to graphviz and the UI.