### PR TITLE
Dashboard & Topology Rework + Panel Polish

### DIFF
--- a/members/nullnet-server/ui/src/components/Layout.tsx
+++ b/members/nullnet-server/ui/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import { useApi } from '../hooks/useApi';
 import type { SessionJson } from '../types';
 import { useRef, useState, useEffect } from 'react';
 
-type Page = 'dashboard' | 'topology' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config' | 'certificates' | 'events';
+type Page = 'dashboard' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config' | 'certificates' | 'events';
 
 interface Props {
   page: Page;
@@ -17,7 +17,6 @@ const NAV = [
     group: 'Overview',
     items: [
       { id: 'dashboard', icon: '⊞', label: 'Dashboard', to: '/' },
-      { id: 'topology', icon: '⬡', label: 'Topology', to: '/topology' },
     ],
   },
   {

--- a/members/nullnet-server/ui/src/components/topology/EdgePanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/EdgePanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { GraphEdgeJson } from '../../types';
+import type { GraphEdgeJson, SessionJson } from '../../types';
 import { spRow, spKey, spCode } from './panelStyles';
 import { useTopologyData } from './TopologyContext';
 
@@ -8,13 +8,19 @@ interface Props {
 }
 
 export default function EdgePanel({ edges }: Props) {
-  const { chains } = useTopologyData();
+  const { chains, sessions } = useTopologyData();
 
   const chainByProxyNetId = useMemo(() => {
     const m = new Map<number, number[]>();
     for (const c of chains ?? []) m.set(c.proxy_net_id, c.all_net_ids);
     return m;
   }, [chains]);
+
+  const sessionByNetId = useMemo(() => {
+    const m = new Map<number, SessionJson>();
+    for (const s of sessions ?? []) m.set(s.network_id, s);
+    return m;
+  }, [sessions]);
 
   if (edges.length === 0) return null;
   const first = edges[0];
@@ -46,31 +52,46 @@ export default function EdgePanel({ edges }: Props) {
         SESSIONS ({edges.length})
       </div>
 
-      {edges.map((e, i) => (
-        <div key={i} style={{
-          background: 'rgba(255,255,255,.03)',
-          border: '1px solid var(--gb)',
-          borderRadius: 6,
-          padding: '9px 11px',
-          marginBottom: 6,
-        }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-            <span style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 10, color: 'var(--cyan)' }}>
-              {e.via_proxy && chainByProxyNetId.has(e.net_id)
-                ? `nets ${chainByProxyNetId.get(e.net_id)!.join(', ')}`
-                : `net ${e.net_id}`}
-            </span>
-            {e.setup_ms > 0 && (
-              <span style={{ fontSize: 10, color: 'var(--t2)' }}>{e.setup_ms}ms setup</span>
+      {edges.map((e, i) => {
+        const session = sessionByNetId.get(e.net_id);
+        return (
+          <div key={i} style={{
+            background: 'rgba(255,255,255,.03)',
+            border: '1px solid var(--gb)',
+            borderRadius: 6,
+            padding: '9px 11px',
+            marginBottom: 6,
+          }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: session || e.via_proxy ? 6 : 0 }}>
+              <span style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 10, color: 'var(--cyan)' }}>
+                {e.via_proxy && chainByProxyNetId.has(e.net_id)
+                  ? `nets ${chainByProxyNetId.get(e.net_id)!.join(', ')}`
+                  : `net ${e.net_id}`}
+              </span>
+              {e.setup_ms > 0 && (
+                <span style={{ fontSize: 10, color: 'var(--t2)' }}>{e.setup_ms}ms setup</span>
+              )}
+            </div>
+            {e.via_proxy && (
+              <div style={{ fontSize: 10, color: '#fbbf24', fontFamily: "'JetBrains Mono',monospace", marginBottom: session ? 6 : 0 }}>
+                via {e.via_proxy}
+              </div>
+            )}
+            {session && (
+              <table style={{ borderCollapse: 'collapse', width: '100%', fontFamily: "'JetBrains Mono',monospace" }}>
+                <tbody>
+                  {[['client', session.client_net], ['server', session.server_net]].map(([label, val]) => (
+                    <tr key={label}>
+                      <td style={{ fontSize: 9, color: 'var(--t2)', paddingRight: 8, paddingTop: 2, whiteSpace: 'nowrap', textTransform: 'uppercase', letterSpacing: '.05em', verticalAlign: 'top' }}>{label}</td>
+                      <td style={{ fontSize: 10, color: 'var(--t1)', wordBreak: 'break-all' }}>{val}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             )}
           </div>
-          {e.via_proxy && (
-            <div style={{ fontSize: 10, color: '#fbbf24', fontFamily: "'JetBrains Mono',monospace" }}>
-              via {e.via_proxy}
-            </div>
-          )}
-        </div>
-      ))}
+        );
+      })}
     </>
   );
 }

--- a/members/nullnet-server/ui/src/components/topology/InternetPanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/InternetPanel.tsx
@@ -1,24 +1,6 @@
-import { useMemo, useState } from 'react';
-import type { SessionJson } from '../../types';
+import { useMemo } from 'react';
 import { spRow, spKey, SpSep } from './panelStyles';
 import { useTopologyData, useTopologyUI } from './TopologyContext';
-
-const PREVIEW_LIMIT = 5;
-
-function groupBySubnet(sessions: SessionJson[]) {
-  const map = new Map<string, SessionJson[]>();
-  for (const s of sessions) {
-    const prefix = s.client_ip.split('.').slice(0, 3).join('.');
-    if (!map.has(prefix)) map.set(prefix, []);
-    map.get(prefix)!.push(s);
-  }
-  return [...map.entries()]
-    .map(([prefix, group]) => ({
-      label: prefix + '.x',
-      sessions: group.sort((a, b) => b.created_at - a.created_at),
-    }))
-    .sort((a, b) => b.sessions.length - a.sessions.length);
-}
 
 function formatTime(unix: number): string {
   return new Date(unix * 1000).toLocaleTimeString([], { hour12: false });
@@ -33,9 +15,11 @@ export default function InternetPanel() {
     for (const c of chains ?? []) m.set(c.proxy_net_id, c.all_net_ids);
     return m;
   }, [chains]);
-  const [expanded, setExpanded] = useState(new Set<string>());
 
-  const sessionList = sessions ?? [];
+  const sessionList = useMemo(
+    () => [...(sessions ?? [])].sort((a, b) => b.created_at - a.created_at),
+    [sessions],
+  );
 
   if (sessionList.length === 0) {
     return (
@@ -45,95 +29,50 @@ export default function InternetPanel() {
     );
   }
 
-  const groups = groupBySubnet(sessionList);
-
   return (
     <>
       <div style={spRow}>
         <div style={spKey}>Summary</div>
-        <div style={{ fontSize: 12, color: 'var(--t0)', display: 'flex', gap: 8, alignItems: 'baseline' }}>
-          <span>
-            <span style={{ color: 'var(--cyan)', fontFamily: "'JetBrains Mono',monospace" }}>{sessionList.length}</span>
-            {' '}client{sessionList.length !== 1 ? 's' : ''}
-          </span>
-          <span style={{ color: 'var(--t3)' }}>·</span>
-          <span>
-            <span style={{ color: 'var(--blue)', fontFamily: "'JetBrains Mono',monospace" }}>{groups.length}</span>
-            {' '}subnet{groups.length !== 1 ? 's' : ''}
-          </span>
+        <div style={{ fontSize: 12, color: 'var(--t0)' }}>
+          <span style={{ color: 'var(--cyan)', fontFamily: "'JetBrains Mono',monospace" }}>{sessionList.length}</span>
+          {' '}client{sessionList.length !== 1 ? 's' : ''}
         </div>
       </div>
 
       <SpSep />
 
-      {groups.map(({ label, sessions: groupSessions }) => {
-        const isExpanded = expanded.has(label);
-        const shown = isExpanded ? groupSessions : groupSessions.slice(0, PREVIEW_LIMIT);
-        const hasMore = groupSessions.length > PREVIEW_LIMIT;
-
-        function toggleExpand() {
-          setExpanded(prev => {
-            const next = new Set(prev);
-            if (isExpanded) next.delete(label); else next.add(label);
-            return next;
-          });
-        }
-
+      {sessionList.map(s => {
+        const isFocused = focusedClientIp === s.client_ip;
         return (
-          <div key={label} style={{ marginBottom: 14 }}>
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 5 }}>
-              <span style={{ fontSize: 10, fontFamily: "'JetBrains Mono',monospace", color: 'var(--blue)', fontWeight: 600 }}>
-                ⬡ {label}
-              </span>
-              <span style={{ fontSize: 9.5, color: 'var(--t2)', fontFamily: "'JetBrains Mono',monospace" }}>
-                {groupSessions.length}
-              </span>
+          <div
+            key={s.id}
+            onClick={() => dispatch({ type: 'CLIENT_FOCUSED', ip: s.client_ip })}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              padding: '5px 6px',
+              marginBottom: 2,
+              borderRadius: 5,
+              border: `1px solid ${isFocused ? 'rgba(91,156,246,.45)' : 'transparent'}`,
+              background: isFocused ? 'rgba(91,156,246,.08)' : 'transparent',
+              cursor: 'pointer',
+              transition: 'background .12s, border-color .12s',
+            }}
+          >
+            <div style={{ width: 6, height: 6, borderRadius: '50%', background: isFocused ? 'var(--blue)' : 'rgba(91,156,246,.4)', flexShrink: 0 }} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 11, fontFamily: "'JetBrains Mono',monospace", color: isFocused ? 'var(--t0)' : 'var(--t1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {s.client_ip}
+              </div>
+              <div style={{ fontSize: 9.5, color: 'var(--t2)' }}>{s.service}</div>
             </div>
-
-            {shown.map(s => {
-              const isFocused = focusedClientIp === s.client_ip;
-              return (
-                <div
-                  key={s.id}
-                  onClick={() => dispatch({ type: 'CLIENT_FOCUSED', ip: s.client_ip })}
-                  style={{
-                    display: 'flex', alignItems: 'center', gap: 8,
-                    padding: '5px 6px',
-                    marginBottom: 2,
-                    borderRadius: 5,
-                    border: `1px solid ${isFocused ? 'rgba(91,156,246,.45)' : 'transparent'}`,
-                    background: isFocused ? 'rgba(91,156,246,.08)' : 'transparent',
-                    cursor: 'pointer',
-                    transition: 'background .12s, border-color .12s',
-                  }}
-                >
-                  <div style={{ width: 6, height: 6, borderRadius: '50%', background: isFocused ? 'var(--blue)' : 'rgba(91,156,246,.4)', flexShrink: 0 }} />
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontSize: 11, fontFamily: "'JetBrains Mono',monospace", color: isFocused ? 'var(--t0)' : 'var(--t1)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
-                      {s.client_ip}
-                    </div>
-                    <div style={{ fontSize: 9.5, color: 'var(--t2)' }}>{s.service}</div>
-                  </div>
-                  <div style={{ flexShrink: 0, textAlign: 'right' as const }}>
-                    <div style={{ fontSize: 9.5, fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
-                      {chainByProxyNetId.has(s.network_id)
-                        ? `nets ${chainByProxyNetId.get(s.network_id)!.join(', ')}`
-                        : `net ${s.network_id}`}
-                    </div>
-                    <div style={{ fontSize: 9, color: 'var(--t2)' }}>{formatTime(s.created_at)}</div>
-                  </div>
-                </div>
-              );
-            })}
-
-            {hasMore && (
-              <button
-                onClick={toggleExpand}
-                style={{ display: 'block', width: '100%', padding: '5px 0', background: 'none', border: 'none', borderTop: '1px solid var(--t3)', color: 'var(--t2)', fontSize: 10, cursor: 'pointer', textAlign: 'left' as const, fontFamily: 'inherit' }}
-              >
-                {isExpanded ? 'Show less' : `+ ${groupSessions.length - PREVIEW_LIMIT} more`}
-              </button>
-            )}
+            <div style={{ flexShrink: 0, textAlign: 'right' }}>
+              <div style={{ fontSize: 9.5, fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
+                {chainByProxyNetId.has(s.network_id)
+                  ? `nets ${chainByProxyNetId.get(s.network_id)!.join(', ')}`
+                  : `net ${s.network_id}`}
+              </div>
+              <div style={{ fontSize: 9, color: 'var(--t2)' }}>{formatTime(s.created_at)}</div>
+            </div>
           </div>
         );
       })}

--- a/members/nullnet-server/ui/src/components/topology/ServiceNodePanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/ServiceNodePanel.tsx
@@ -31,7 +31,22 @@ export default function ServiceNodePanel({ node, service, onDepClick }: Props) {
 
       <div style={spRow}>
         <div style={spKey}>Replicas</div>
-        <div style={spVal}>{node.active_replica_count} active / {node.paused_replica_count} paused / {node.replica_count} total</div>
+        <table style={{ borderCollapse: 'collapse', fontSize: 11, fontFamily: "'JetBrains Mono',monospace" }}>
+          <thead>
+            <tr>
+              {(['active', 'paused', 'total'] as const).map(h => (
+                <th key={h} style={{ fontSize: 9, color: 'var(--t2)', paddingBottom: 3, paddingRight: 14, textAlign: 'right', letterSpacing: '.05em', fontWeight: 500, textTransform: 'uppercase', fontFamily: 'inherit' }}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style={{ paddingRight: 14, textAlign: 'right', color: 'var(--green)' }}>{node.active_replica_count}</td>
+              <td style={{ paddingRight: 14, textAlign: 'right', color: node.paused_replica_count > 0 ? '#fbbf24' : 'var(--t2)' }}>{node.paused_replica_count}</td>
+              <td style={{ textAlign: 'right', color: 'var(--t1)' }}>{node.replica_count}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
 
       {service?.timeout_secs != null && (

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
@@ -115,6 +115,13 @@ export default function TopologyGraphSvg({
         const session: SessionJson | null = isFocusedEdge
           ? (focusedSessions?.find(s => e.originalIndices.some(idx => graph.edges[idx]?.net_id === s.network_id)) ?? null)
           : null;
+        // For chain hops the session is null (chain sessions don't carry the client IP),
+        // but we can still display the VNI by pulling it directly from the graph edge.
+        const focusedNetId: number | null = isFocusedEdge
+          ? (session?.network_id ??
+             e.originalIndices.map(idx => graph.edges[idx]?.net_id).find(id => id !== undefined && focusedNetIds!.has(id)) ??
+             null)
+          : null;
         const lp = isFocusedEdge ? edgeLabelPoints(fp, tp) : null;
         const srcIp = isFocusedEdge ? getNodeIp(e.from) : null;
         const dstIp = isFocusedEdge ? getNodeIp(e.to) : null;
@@ -169,22 +176,26 @@ export default function TopologyGraphSvg({
                     </text>
                   </g>
                 )}
-                {session && (
+                {focusedNetId !== null && (
                   <g>
-                    <rect x={lp.mid.x - 60} y={lp.mid.y - 15} width={120} height={32} rx="4"
+                    <rect x={lp.mid.x - 60} y={lp.mid.y - 15} width={120} height={session ? 32 : 16} rx="4"
                       fill="rgba(3,5,8,.88)" stroke="rgba(255,255,255,.07)" />
                     <text x={lp.mid.x} y={lp.mid.y - 6} textAnchor="middle"
                       fill="rgba(91,156,246,.9)" fontSize="8" fontWeight="600">
-                      VNI {session.network_id}
+                      VNI {focusedNetId}
                     </text>
-                    <text x={lp.mid.x} y={lp.mid.y + 4} textAnchor="middle"
-                      fill="rgba(255,255,255,.5)" fontSize="7" fontFamily="'JetBrains Mono',monospace">
-                      <tspan fill="rgba(255,255,255,.3)">src  </tspan>{session.client_net}
-                    </text>
-                    <text x={lp.mid.x} y={lp.mid.y + 13} textAnchor="middle"
-                      fill="rgba(255,255,255,.5)" fontSize="7" fontFamily="'JetBrains Mono',monospace">
-                      <tspan fill="rgba(255,255,255,.3)">dst  </tspan>{session.server_net}
-                    </text>
+                    {session && (
+                      <>
+                        <text x={lp.mid.x} y={lp.mid.y + 4} textAnchor="middle"
+                          fill="rgba(255,255,255,.5)" fontSize="7" fontFamily="'JetBrains Mono',monospace">
+                          <tspan fill="rgba(255,255,255,.3)">src  </tspan>{session.client_net}
+                        </text>
+                        <text x={lp.mid.x} y={lp.mid.y + 13} textAnchor="middle"
+                          fill="rgba(255,255,255,.5)" fontSize="7" fontFamily="'JetBrains Mono',monospace">
+                          <tspan fill="rgba(255,255,255,.3)">dst  </tspan>{session.server_net}
+                        </text>
+                      </>
+                    )}
                   </g>
                 )}
               </g>

--- a/members/nullnet-server/ui/src/components/topology/TopologyPanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyPanel.tsx
@@ -61,7 +61,7 @@ export default function TopologyPanel() {
     }}>
       <div className="drag-handle" onMouseDown={onResizeStart} />
       <div style={{ padding: '14px 18px', borderBottom: '1px solid var(--t3)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
-        <span style={{
+        <span title={getTitle()} style={{
           fontSize: 13, fontWeight: 600, color: 'var(--t0)',
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
           maxWidth: width - 58, fontFamily: "'JetBrains Mono',monospace",

--- a/members/nullnet-server/ui/src/components/topology/TopologyPanel.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyPanel.tsx
@@ -3,10 +3,12 @@ import ServiceNodePanel from './ServiceNodePanel';
 import ProxyNodePanel from './ProxyNodePanel';
 import EdgePanel from './EdgePanel';
 import InternetPanel from './InternetPanel';
+import { useDragResize } from '../../hooks/useDragResize';
 
 export default function TopologyPanel() {
   const { graph, services } = useTopologyData();
   const { panel, dispatch } = useTopologyUI();
+  const { width, onResizeStart } = useDragResize(268, 200, 560);
 
   if (!graph) return null;
 
@@ -48,7 +50,7 @@ export default function TopologyPanel() {
 
   return (
     <div style={{
-      position: 'fixed', top: 48, right: 0, bottom: 0, width: 268,
+      position: 'fixed', top: 48, right: 0, bottom: 0, width,
       background: 'rgba(3,5,8,.95)',
       backdropFilter: 'blur(28px)', WebkitBackdropFilter: 'blur(28px)',
       borderLeft: '1px solid var(--gb)',
@@ -57,11 +59,12 @@ export default function TopologyPanel() {
       transition: 'transform .22s cubic-bezier(.4,0,.2,1)',
       zIndex: 50,
     }}>
+      <div className="drag-handle" onMouseDown={onResizeStart} />
       <div style={{ padding: '14px 18px', borderBottom: '1px solid var(--t3)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <span style={{
           fontSize: 13, fontWeight: 600, color: 'var(--t0)',
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-          maxWidth: 210, fontFamily: "'JetBrains Mono',monospace",
+          maxWidth: width - 58, fontFamily: "'JetBrains Mono',monospace",
         }}>
           {getTitle()}
         </span>

--- a/members/nullnet-server/ui/src/hooks/useDragResize.ts
+++ b/members/nullnet-server/ui/src/hooks/useDragResize.ts
@@ -1,0 +1,34 @@
+import { useCallback, useRef, useState } from 'react';
+
+export function useDragResize(initialWidth: number, min = 180, max = 600) {
+  const [width, setWidth] = useState(initialWidth);
+  const widthRef = useRef(width);
+  widthRef.current = width;
+
+  const onResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = widthRef.current;
+
+      const onMove = (ev: MouseEvent) => {
+        setWidth(Math.min(max, Math.max(min, startWidth + (startX - ev.clientX))));
+      };
+
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [min, max],
+  );
+
+  return { width, onResizeStart };
+}

--- a/members/nullnet-server/ui/src/index.css
+++ b/members/nullnet-server/ui/src/index.css
@@ -245,7 +245,9 @@ body {
 .nc-stat-v { font-size: 16px; font-weight: 700; font-family: 'Syne', sans-serif; letter-spacing: -.02em; }
 .nc-svcs { padding: 10px 18px; border-top: 1px solid var(--t3); display: flex; flex-wrap: wrap; gap: 5px; }
 .svc-tag { font-size: 10px; padding: 2px 9px; background: rgba(255,255,255,.05); border: 1px solid var(--t3); color: var(--t1); border-radius: 20px; }
-.dp { width: 300px; background: rgba(3,5,8,.9); backdrop-filter: blur(28px); -webkit-backdrop-filter: blur(28px); border-left: 1px solid var(--gb); box-shadow: inset 0 1px 0 rgba(255,255,255,.07); display: flex; flex-direction: column; flex-shrink: 0; overflow: hidden; }
+.dp { width: 300px; background: rgba(3,5,8,.9); backdrop-filter: blur(28px); -webkit-backdrop-filter: blur(28px); border-left: 1px solid var(--gb); box-shadow: inset 0 1px 0 rgba(255,255,255,.07); display: flex; flex-direction: column; flex-shrink: 0; overflow: hidden; position: relative; }
+.drag-handle { position: absolute; left: 0; top: 0; bottom: 0; width: 4px; cursor: col-resize; z-index: 1; transition: background .15s; }
+.drag-handle:hover { background: rgba(255,255,255,.09); }
 .dp-head { padding: 16px 18px; border-bottom: 1px solid var(--t3); display: flex; align-items: center; justify-content: space-between; }
 .dp-title { font-size: 13px; font-weight: 700; }
 .dp-close { background: none; border: none; color: var(--t2); cursor: pointer; font-size: 18px; padding: 0; transition: color .1s; }

--- a/members/nullnet-server/ui/src/pages/Dashboard.tsx
+++ b/members/nullnet-server/ui/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Layout from '../components/Layout';
 import { useApi } from '../hooks/useApi';
 import { useStack } from '../StackContext';
@@ -11,6 +11,7 @@ function DashboardView() {
   const { stack } = useStack();
   const { graph, sessions, chains } = useTopologyData();
   const { panel, dispatch } = useTopologyUI();
+  const [connectionsOpen, setConnectionsOpen] = useState(true);
 
   const { data: nodes } = useApi<NodeJson[]>(`/api/nodes/${stack}`, 5000);
   const { data: pool } = useApi<PoolJson>('/api/pool', 5000);
@@ -59,26 +60,23 @@ function DashboardView() {
           ))}
         </div>
 
-        {/* Full-width topology card */}
-        <div className="card glass">
-          <div className="card-head">
-            <span className="card-label">Service Topology</span>
-            <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', gap: 10, alignItems: 'center' }}>
-              {graph ? (
-                <>
-                  <span>{nodeCountG} services</span>
-                  {proxyCount > 0 && <span style={{ color: '#fbbf24' }}>{proxyCount} prox{proxyCount === 1 ? 'y' : 'ies'}</span>}
-                  <span>{edgeCount} edges</span>
-                </>
-              ) : 'loading…'}
-            </span>
-          </div>
-
-          {/* Active Connections — scrollable table pinned above the graph */}
-          {graph && graph.edges.length > 0 && (
-            <div style={{ maxHeight: 200, overflowY: 'auto', borderBottom: '1px solid var(--t3)' }}>
+        {/* Active Connections — collapsible card */}
+        {graph && graph.edges.length > 0 && (
+          <div className="card glass" style={{ marginBottom: 12 }}>
+            <div
+              className="card-head"
+              onClick={() => setConnectionsOpen(v => !v)}
+              style={{ cursor: 'pointer', userSelect: 'none' }}
+            >
+              <span className="card-label">Active Connections</span>
+              <span style={{ display: 'flex', gap: 10, alignItems: 'center', fontSize: 10, color: 'var(--t2)' }}>
+                <span>{edgeCount} edge{edgeCount !== 1 ? 's' : ''}</span>
+                <span style={{ fontSize: 11, lineHeight: 1 }}>{connectionsOpen ? '▾' : '▸'}</span>
+              </span>
+            </div>
+            {connectionsOpen && (
               <table className="tbl">
-                <thead style={{ position: 'sticky', top: 0, zIndex: 1, background: 'rgba(6,9,13,.97)' }}>
+                <thead>
                   <tr>
                     <th>From</th>
                     <th>Via Proxy</th>
@@ -127,8 +125,24 @@ function DashboardView() {
                   })}
                 </tbody>
               </table>
-            </div>
-          )}
+            )}
+          </div>
+        )}
+
+        {/* Full-width topology card */}
+        <div className="card glass">
+          <div className="card-head">
+            <span className="card-label">Service Topology</span>
+            <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', gap: 10, alignItems: 'center' }}>
+              {graph ? (
+                <>
+                  <span>{nodeCountG} services</span>
+                  {proxyCount > 0 && <span style={{ color: '#fbbf24' }}>{proxyCount} prox{proxyCount === 1 ? 'y' : 'ies'}</span>}
+                  <span>{edgeCount} edges</span>
+                </>
+              ) : 'loading…'}
+            </span>
+          </div>
 
           {/* Graph */}
           <div style={{ background: 'rgba(0,0,0,.25)' }}>

--- a/members/nullnet-server/ui/src/pages/Dashboard.tsx
+++ b/members/nullnet-server/ui/src/pages/Dashboard.tsx
@@ -21,6 +21,12 @@ function DashboardView() {
     return m;
   }, [chains]);
 
+  const sessionByNetId = useMemo(() => {
+    const m = new Map<number, NonNullable<typeof sessions>[number]>();
+    for (const s of sessions ?? []) m.set(s.network_id, s);
+    return m;
+  }, [sessions]);
+
   const sessionCount = sessions?.length ?? 0;
   const nodeCount = nodes?.length ?? 0;
   const edgeCount = graph?.edges.length ?? 0;
@@ -78,36 +84,47 @@ function DashboardView() {
                     <th>Via Proxy</th>
                     <th>To</th>
                     <th>Net ID</th>
+                    <th>Client Net</th>
+                    <th>Server Net</th>
                     <th>Setup</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {graph.edges.map((e, i) => (
-                    <tr
-                      key={i}
-                      onClick={() => dispatch({ type: 'EDGE_CLICKED', fromId: e.from, toId: e.to, edgeIndices: [i] })}
-                      style={{
-                        cursor: 'pointer',
-                        background: panel?.type === 'edge' && panel.edgeIndices.includes(i)
-                          ? 'rgba(91,156,246,.07)'
-                          : undefined,
-                      }}
-                    >
-                      <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.from}</td>
-                      <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: '#fbbf24' }}>
-                        {e.via_proxy ?? <span style={{ color: 'var(--t3)' }}>—</span>}
-                      </td>
-                      <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.to}</td>
-                      <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
-                        {e.via_proxy && chainByProxyNetId.has(e.net_id)
-                          ? chainByProxyNetId.get(e.net_id)!.join(', ')
-                          : e.net_id}
-                      </td>
-                      <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
-                        {e.setup_ms > 0 ? `${e.setup_ms}ms` : '—'}
-                      </td>
-                    </tr>
-                  ))}
+                  {graph.edges.map((e, i) => {
+                    const session = sessionByNetId.get(e.net_id);
+                    return (
+                      <tr
+                        key={i}
+                        onClick={() => dispatch({ type: 'EDGE_CLICKED', fromId: e.from, toId: e.to, edgeIndices: [i] })}
+                        style={{
+                          cursor: 'pointer',
+                          background: panel?.type === 'edge' && panel.edgeIndices.includes(i)
+                            ? 'rgba(91,156,246,.07)'
+                            : undefined,
+                        }}
+                      >
+                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.from}</td>
+                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: '#fbbf24' }}>
+                          {e.via_proxy ?? <span style={{ color: 'var(--t3)' }}>—</span>}
+                        </td>
+                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.to}</td>
+                        <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
+                          {e.via_proxy && chainByProxyNetId.has(e.net_id)
+                            ? chainByProxyNetId.get(e.net_id)!.join(', ')
+                            : e.net_id}
+                        </td>
+                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: 'var(--t1)' }}>
+                          {session?.client_net ?? <span style={{ color: 'var(--t3)' }}>—</span>}
+                        </td>
+                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: 'var(--t1)' }}>
+                          {session?.server_net ?? <span style={{ color: 'var(--t3)' }}>—</span>}
+                        </td>
+                        <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
+                          {e.setup_ms > 0 ? `${e.setup_ms}ms` : '—'}
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/members/nullnet-server/ui/src/pages/Dashboard.tsx
+++ b/members/nullnet-server/ui/src/pages/Dashboard.tsx
@@ -1,145 +1,169 @@
+import { useMemo } from 'react';
 import Layout from '../components/Layout';
 import { useApi } from '../hooks/useApi';
 import { useStack } from '../StackContext';
-import type { SessionJson, ServiceJson, NodeJson, PoolJson, GraphJson } from '../types';
-import TopologyGraphSvg from '../components/topology/TopologyGraphSvg';
-import ZoomFrame from '../components/topology/ZoomFrame';
+import type { NodeJson, PoolJson } from '../types';
+import { TopologyProvider, useTopologyData, useTopologyUI } from '../components/topology/TopologyContext';
+import TopologyGraph from '../components/topology/TopologyGraph';
+import TopologyPanel from '../components/topology/TopologyPanel';
+
+function DashboardView() {
+  const { stack } = useStack();
+  const { graph, sessions, chains } = useTopologyData();
+  const { panel, dispatch } = useTopologyUI();
+
+  const { data: nodes } = useApi<NodeJson[]>(`/api/nodes/${stack}`, 5000);
+  const { data: pool } = useApi<PoolJson>('/api/pool', 5000);
+
+  const chainByProxyNetId = useMemo(() => {
+    const m = new Map<number, number[]>();
+    for (const c of chains ?? []) m.set(c.proxy_net_id, c.all_net_ids);
+    return m;
+  }, [chains]);
+
+  const sessionCount = sessions?.length ?? 0;
+  const nodeCount = nodes?.length ?? 0;
+  const edgeCount = graph?.edges.length ?? 0;
+  const nodeCountG = graph?.nodes.length ?? 0;
+  const proxyCount = graph
+    ? new Set(graph.edges.filter(e => e.via_proxy).map(e => e.via_proxy!)).size
+    : 0;
+  const poolPct = pool ? ((pool.in_use / pool.total) * 100).toFixed(1) : '—';
+  const poolUsed = pool ? `${pool.in_use.toLocaleString()} / ${pool.total.toLocaleString()}` : '—';
+
+  const stats = [
+    { label: 'Active Sessions', value: sessionCount, color: 'var(--cyan)',  sub: 'isolated networks' },
+    { label: 'Connected Nodes', value: nodeCount,    color: 'var(--green)', sub: 'agent nodes' },
+    { label: 'Active Edges',    value: edgeCount,    color: 'var(--blue)',  sub: 'live connections' },
+    { label: 'Pool Used',       value: pool ? `${poolPct}%` : '—', color: 'var(--t0)', sub: poolUsed },
+  ];
+
+  return (
+    <>
+      <div className="content">
+
+        {/* Compact stat row */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: 20 }}>
+          {stats.map(({ label, value, color, sub }) => (
+            <div key={label} className="stat glass" style={{ padding: '12px 16px' }}>
+              <div className="stat-label">{label}</div>
+              <div className="stat-value" style={{ fontSize: 20, color }}>{value}</div>
+              <div className="stat-sub">{sub}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Full-width topology card */}
+        <div className="card glass">
+          <div className="card-head">
+            <span className="card-label">Service Topology</span>
+            <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', gap: 10, alignItems: 'center' }}>
+              {graph ? (
+                <>
+                  <span>{nodeCountG} services</span>
+                  {proxyCount > 0 && <span style={{ color: '#fbbf24' }}>{proxyCount} prox{proxyCount === 1 ? 'y' : 'ies'}</span>}
+                  <span>{edgeCount} edges</span>
+                </>
+              ) : 'loading…'}
+            </span>
+          </div>
+
+          {/* Active Connections — scrollable table pinned above the graph */}
+          {graph && graph.edges.length > 0 && (
+            <div style={{ maxHeight: 200, overflowY: 'auto', borderBottom: '1px solid var(--t3)' }}>
+              <table className="tbl">
+                <thead style={{ position: 'sticky', top: 0, zIndex: 1, background: 'rgba(6,9,13,.97)' }}>
+                  <tr>
+                    <th>From</th>
+                    <th>Via Proxy</th>
+                    <th>To</th>
+                    <th>Net ID</th>
+                    <th>Setup</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {graph.edges.map((e, i) => (
+                    <tr
+                      key={i}
+                      onClick={() => dispatch({ type: 'EDGE_CLICKED', fromId: e.from, toId: e.to, edgeIndices: [i] })}
+                      style={{
+                        cursor: 'pointer',
+                        background: panel?.type === 'edge' && panel.edgeIndices.includes(i)
+                          ? 'rgba(91,156,246,.07)'
+                          : undefined,
+                      }}
+                    >
+                      <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.from}</td>
+                      <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: '#fbbf24' }}>
+                        {e.via_proxy ?? <span style={{ color: 'var(--t3)' }}>—</span>}
+                      </td>
+                      <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.to}</td>
+                      <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
+                        {e.via_proxy && chainByProxyNetId.has(e.net_id)
+                          ? chainByProxyNetId.get(e.net_id)!.join(', ')
+                          : e.net_id}
+                      </td>
+                      <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
+                        {e.setup_ms > 0 ? `${e.setup_ms}ms` : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Graph */}
+          <div style={{ background: 'rgba(0,0,0,.25)' }}>
+            {!graph && (
+              <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
+                loading topology…
+              </div>
+            )}
+            {graph && graph.nodes.length === 0 && (
+              <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
+                No services registered for stack <b>{stack}</b>
+              </div>
+            )}
+            {graph && graph.nodes.length > 0 && <TopologyGraph />}
+          </div>
+
+          {/* Legend */}
+          {proxyCount > 0 && (
+            <div style={{ padding: '8px 14px 10px', display: 'flex', gap: 16, fontSize: 10, color: 'var(--t2)', borderTop: '1px solid var(--gb)' }}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ width: 20, height: 1.5, background: 'rgba(255,255,255,.25)', display: 'inline-block' }} />
+                direct
+              </span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span style={{ width: 20, height: 1.5, display: 'inline-block', backgroundImage: 'repeating-linear-gradient(90deg,rgba(251,191,36,.45) 0,rgba(251,191,36,.45) 4px,transparent 4px,transparent 7px)' }} />
+                via proxy
+              </span>
+            </div>
+          )}
+        </div>
+
+      </div>
+
+      <TopologyPanel />
+    </>
+  );
+}
 
 export default function Dashboard() {
   const { stack } = useStack();
-  const { data: sessions } = useApi<SessionJson[]>(`/api/sessions/${stack}`, 5000);
-  const { data: services } = useApi<ServiceJson[]>(`/api/services/${stack}`, 5000);
-  const { data: nodes } = useApi<NodeJson[]>(`/api/nodes/${stack}`, 5000);
-  const { data: pool } = useApi<PoolJson>('/api/pool', 5000);
-  const { data: graph } = useApi<GraphJson>(`/api/graph/${stack}`, 5000);
-
-  const totalSvc = services?.length ?? 0;
-  const onlineSvc = services?.filter(s => s.registered).length ?? 0;
-  const sessionCount = sessions?.length ?? 0;
-  const nodeCount = nodes?.length ?? 0;
-  const poolPct = pool ? ((pool.in_use / pool.total) * 100).toFixed(1) : '—';
-  const poolUsed = pool ? `${pool.in_use.toLocaleString()} of ${pool.total.toLocaleString()} IDs` : '—';
-
   return (
     <Layout
       page="dashboard"
       topbarRight={
         <span style={{ fontSize: 11, color: 'var(--t1)', display: 'flex', alignItems: 'center', gap: 5 }}>
-          <span className="live-dot"></span>live · 5s
+          <span className="live-dot" />live · SSE
         </span>
       }
     >
-      <div className="content">
-        <div className="stats">
-          <div className="stat glass">
-            <div className="stat-label">Services Online</div>
-            <div className="stat-value">
-              {onlineSvc}<span className="denom">/{totalSvc}</span>
-            </div>
-            <div className="stat-sub">{totalSvc - onlineSvc} unregistered</div>
-          </div>
-          <div className="stat glass">
-            <div className="stat-label">Active Sessions</div>
-            <div className="stat-value" style={{ color: 'var(--cyan)' }}>{sessionCount}</div>
-            <div className="stat-sub">isolated networks</div>
-          </div>
-          <div className="stat glass">
-            <div className="stat-label">Connected Nodes</div>
-            <div className="stat-value" style={{ color: 'var(--green)' }}>{nodeCount}</div>
-            <div className="stat-sub">agent nodes</div>
-          </div>
-          <div className="stat glass">
-            <div className="stat-label">Pool Used</div>
-            <div className="stat-value">
-              {pool ? <>{poolPct}<span className="denom">%</span></> : '—'}
-            </div>
-            <div className="stat-sub">{poolUsed}</div>
-          </div>
-        </div>
-
-        <div className="bot-grid">
-          <div className="card glass">
-            <div className="card-head">
-              <span className="card-label">Topology</span>
-              <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', alignItems: 'center', gap: 5 }}>
-                <span className="live-dot" />live · 5s
-              </span>
-            </div>
-            <div style={{ background: 'rgba(0,0,0,.25)' }}>
-              {!graph && (
-                <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>loading topology…</div>
-              )}
-              {graph && (
-                <ZoomFrame height={280}>
-                  <TopologyGraphSvg graph={graph} />
-                </ZoomFrame>
-              )}
-            </div>
-          </div>
-
-          <div className="card glass">
-            <div className="card-head">
-              <span className="card-label">Recent Sessions</span>
-            </div>
-            {sessions && sessions.length > 0 ? (
-              sessions.slice(0, 6).map(s => (
-                <div key={s.id} className="ev">
-                  <div className="ev-accent" style={{ background: 'var(--green)' }}></div>
-                  <span className="ev-time">{new Date(s.created_at * 1000).toLocaleTimeString()}</span>
-                  <span className="ev-text">
-                    <b>NET {s.id}</b> — {s.service} ← {s.client_ip}
-                  </span>
-                </div>
-              ))
-            ) : (
-              <div style={{ padding: '20px 18px', color: 'var(--t2)', fontSize: 11 }}>
-                {sessions === null ? 'Loading…' : 'No active sessions'}
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="card glass" style={{ marginTop: 12 }}>
-          <div className="card-head">
-            <span className="card-label">Services</span>
-            <span style={{ fontSize: 10, color: 'var(--t2)' }}>{onlineSvc}/{totalSvc} online</span>
-          </div>
-          <table className="tbl">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Status</th>
-                <th>Replicas</th>
-                <th>Dependencies</th>
-                <th>Timeout</th>
-              </tr>
-            </thead>
-            <tbody>
-              {services?.map(svc => (
-                <tr key={svc.name}>
-                  <td style={{ fontWeight: 500 }}>{svc.name}</td>
-                  <td>
-                    <span className={`badge ${svc.registered ? 'b-green' : 'b-dim'}`}>
-                      {svc.registered ? 'Online' : 'Offline'}
-                    </span>
-                  </td>
-                  <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t1)' }}>
-                    {svc.replicas.length}
-                  </td>
-                  <td>
-                    {svc.proxy_dependencies.flat().map((d, i) => (
-                      <span key={`${d}-${i}`} className="dep-tag">{d}</span>
-                    ))}
-                  </td>
-                  <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
-                    {svc.timeout_secs != null ? `${svc.timeout_secs}s` : '—'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <TopologyProvider stack={stack}>
+        <DashboardView />
+      </TopologyProvider>
     </Layout>
   );
 }

--- a/members/nullnet-server/ui/src/pages/Dashboard.tsx
+++ b/members/nullnet-server/ui/src/pages/Dashboard.tsx
@@ -35,46 +35,54 @@ function DashboardView() {
   const proxyCount = graph
     ? new Set(graph.edges.filter(e => e.via_proxy).map(e => e.via_proxy!)).size
     : 0;
-  const poolPct = pool ? ((pool.in_use / pool.total) * 100).toFixed(1) : '—';
-  const poolUsed = pool ? `${pool.in_use.toLocaleString()} / ${pool.total.toLocaleString()}` : '—';
-
-  const stats = [
-    { label: 'Active Sessions', value: sessionCount, color: 'var(--cyan)',  sub: 'isolated networks' },
-    { label: 'Connected Nodes', value: nodeCount,    color: 'var(--green)', sub: 'agent nodes' },
-    { label: 'Active Edges',    value: edgeCount,    color: 'var(--blue)',  sub: 'live connections' },
-    { label: 'Pool Used',       value: pool ? `${poolPct}%` : '—', color: 'var(--t0)', sub: poolUsed },
-  ];
+  const poolPct = pool ? ((pool.in_use / pool.total) * 100).toFixed(1) : null;
 
   return (
     <>
       <div className="content">
 
-        {/* Compact stat row */}
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: 20 }}>
-          {stats.map(({ label, value, color, sub }) => (
-            <div key={label} className="stat glass" style={{ padding: '12px 16px' }}>
-              <div className="stat-label">{label}</div>
-              <div className="stat-value" style={{ fontSize: 20, color }}>{value}</div>
-              <div className="stat-sub">{sub}</div>
-            </div>
-          ))}
-        </div>
-
-        {/* Active Connections — collapsible card */}
-        {graph && graph.edges.length > 0 && (
-          <div className="card glass" style={{ marginBottom: 12 }}>
-            <div
-              className="card-head"
-              onClick={() => setConnectionsOpen(v => !v)}
-              style={{ cursor: 'pointer', userSelect: 'none' }}
-            >
-              <span className="card-label">Active Connections</span>
-              <span style={{ display: 'flex', gap: 10, alignItems: 'center', fontSize: 10, color: 'var(--t2)' }}>
-                <span>{edgeCount} edge{edgeCount !== 1 ? 's' : ''}</span>
-                <span style={{ fontSize: 11, lineHeight: 1 }}>{connectionsOpen ? '▾' : '▸'}</span>
+        {/* Active Connections — always-visible collapsible card with stats in header */}
+        <div className="card glass" style={{ marginBottom: 12 }}>
+          <div
+            className="card-head"
+            onClick={() => setConnectionsOpen(v => !v)}
+            style={{ cursor: 'pointer', userSelect: 'none' }}
+          >
+            <span className="card-label">Active Connections</span>
+            <span style={{ display: 'flex', gap: 14, alignItems: 'center', fontSize: 10, color: 'var(--t2)' }}>
+              <span>
+                <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)', marginRight: 4 }}>{sessionCount}</span>
+                sessions
               </span>
-            </div>
-            {connectionsOpen && (
+              <span style={{ color: 'var(--t3)' }}>·</span>
+              <span>
+                <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--green)', marginRight: 4 }}>{nodeCount}</span>
+                nodes
+              </span>
+              <span style={{ color: 'var(--t3)' }}>·</span>
+              <span>
+                <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--blue)', marginRight: 4 }}>{edgeCount}</span>
+                edges
+              </span>
+              {poolPct !== null && (
+                <>
+                  <span style={{ color: 'var(--t3)' }}>·</span>
+                  <span>
+                    <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t1)', marginRight: 4 }}>{poolPct}%</span>
+                    pool
+                  </span>
+                </>
+              )}
+              <span style={{ fontSize: 11, lineHeight: 1, marginLeft: 2 }}>{connectionsOpen ? '▾' : '▸'}</span>
+            </span>
+          </div>
+
+          {connectionsOpen && (
+            edgeCount === 0 ? (
+              <div style={{ padding: '20px 18px', color: 'var(--t2)', fontSize: 11, textAlign: 'center' }}>
+                No active connections
+              </div>
+            ) : (
               <table className="tbl">
                 <thead>
                   <tr>
@@ -88,7 +96,7 @@ function DashboardView() {
                   </tr>
                 </thead>
                 <tbody>
-                  {graph.edges.map((e, i) => {
+                  {graph!.edges.map((e, i) => {
                     const session = sessionByNetId.get(e.net_id);
                     return (
                       <tr
@@ -125,9 +133,9 @@ function DashboardView() {
                   })}
                 </tbody>
               </table>
-            )}
-          </div>
-        )}
+            )
+          )}
+        </div>
 
         {/* Full-width topology card */}
         <div className="card glass">
@@ -144,7 +152,6 @@ function DashboardView() {
             </span>
           </div>
 
-          {/* Graph */}
           <div style={{ background: 'rgba(0,0,0,.25)' }}>
             {!graph && (
               <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
@@ -159,7 +166,6 @@ function DashboardView() {
             {graph && graph.nodes.length > 0 && <TopologyGraph />}
           </div>
 
-          {/* Legend */}
           {proxyCount > 0 && (
             <div style={{ padding: '8px 14px 10px', display: 'flex', gap: 16, fontSize: 10, color: 'var(--t2)', borderTop: '1px solid var(--gb)' }}>
               <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>

--- a/members/nullnet-server/ui/src/pages/Nodes.tsx
+++ b/members/nullnet-server/ui/src/pages/Nodes.tsx
@@ -81,7 +81,7 @@ export default function Nodes() {
         <div className="dp" style={{ width: dpWidth }}>
           <div className="drag-handle" onMouseDown={onResizeStart} />
           <div className="dp-head">
-            <span className="dp-title">{selectedNode ? selectedNode.ip : '–'}</span>
+            <span className="dp-title" title={selectedNode?.ip}>{selectedNode ? selectedNode.ip : '–'}</span>
             {selectedNode && (
               <button className="dp-close" onClick={() => setSelected(null)}>✕</button>
             )}

--- a/members/nullnet-server/ui/src/pages/Nodes.tsx
+++ b/members/nullnet-server/ui/src/pages/Nodes.tsx
@@ -3,11 +3,13 @@ import Layout from '../components/Layout';
 import { useApi } from '../hooks/useApi';
 import { useStack } from '../StackContext';
 import type { NodeJson } from '../types';
+import { useDragResize } from '../hooks/useDragResize';
 
 export default function Nodes() {
   const { stack } = useStack();
   const { data: nodes, loading } = useApi<NodeJson[]>(`/api/nodes/${stack}`, 5000);
   const [selected, setSelected] = useState<string | null>(null);
+  const { width: dpWidth, onResizeStart } = useDragResize(300, 200, 560);
 
   const selectedNode = nodes?.find(n => n.ip === selected) ?? null;
 
@@ -76,7 +78,8 @@ export default function Nodes() {
           </div>
         </div>
 
-        <div className="dp">
+        <div className="dp" style={{ width: dpWidth }}>
+          <div className="drag-handle" onMouseDown={onResizeStart} />
           <div className="dp-head">
             <span className="dp-title">{selectedNode ? selectedNode.ip : '–'}</span>
             {selectedNode && (

--- a/members/nullnet-server/ui/src/pages/Topology.tsx
+++ b/members/nullnet-server/ui/src/pages/Topology.tsx
@@ -144,7 +144,7 @@ export default function Topology() {
   const { stack } = useStack();
   return (
     <Layout
-      page="topology"
+      page="dashboard"
       topbarRight={
         <span style={{ fontSize: 11, color: 'var(--t1)', display: 'flex', alignItems: 'center', gap: 5 }}>
           <span className="live-dot" />live · SSE


### PR DESCRIPTION
# UI: Dashboard & Topology Rework + Panel Polish

## Summary

This PR consolidates the Dashboard and Topology pages into a single view, fixes a VNI label bug on chain edges, and adds several UX improvements to the side panels and data tables.

---

## Changes

### Dashboard / Topology merge

- **Merged Topology into Dashboard.** The separate Topology page was a near-duplicate of the dashboard graph card. Dashboard now owns the full interactive topology experience via `TopologyProvider` — click-to-inspect nodes and edges, client focus, and the slide-in panel all work directly from the dashboard.
- **Removed Topology from the nav and deleted the page.** The `/topology` route, `Topology.tsx`, and its nav entry are all gone.
- **Removed "Recent Sessions" and "Services" sections** from the old Dashboard. Sessions have a dedicated tab; the services table added noise without value on the overview page.

### Active Connections card

- Extracted into its own **collapsible card** above the topology graph (previously embedded inside the topology card).
- The card is **always visible** — when there are no edges it shows an empty state instead of disappearing.
- **Stats folded into the card header** as a compact inline strip (`12 sessions · 3 nodes · 5 edges · 2.1% pool`), replacing the four large stat boxes that dominated the top of the page.
- Added **Client Net** and **Server Net** columns (overlay network CIDRs from the matching session).

### Edge panel (side drawer)

- Each session card now shows **client and server overlay network IPs** (`client_net` / `server_net`) pulled from the sessions API by matching `network_id`.

### VNI badge on chain edges

- **Fixed:** when a client is focused, only the proxy→entry-service edge showed a VNI badge. Chain hop edges (service→service after the proxy) were skipped because their `net_id` values don't appear in `focusedSessions` (proxy-level sessions only).
- Fix derives `focusedNetId` directly from the graph edge when no session match exists, so all edges in the chain get a VNI label. The proxy edge keeps its full VNI + CIDR display; chain edges get a compact VNI-only badge.

### Side panels — resizable

- Both the Topology side panel and the Nodes detail panel (`.dp`) are now **resizable by dragging the left edge**.
- New `useDragResize` hook captures `startX` / `startWidth` on `mousedown`, updates width via `document` `mousemove`, and restores cursor on `mouseup`. Width is clamped to `[200, 560]px`.
- A 4 px drag handle sits on the left edge of each panel with a subtle hover highlight.
- Panel title `<span>` elements have a `title` attribute for truncated-text tooltips.

### Internet panel

- Dropped subnet grouping (`groupBySubnet`, `expanded` state, expand/collapse per group).
- Now a flat list sorted newest-first. Subnet re-grouping can be revisited later with a better UX.

### Replica counts in service node panel

- The `N active / M paused / P total` string is now rendered as a **mini table** with aligned column headers (`ACTIVE`, `PAUSED`, `TOTAL`). Paused count turns amber when non-zero.
