### PR TITLE
Dashboard redesign and dedicated Topology page

### DIFF
--- a/members/nullnet-server/ui/src/components/Layout.tsx
+++ b/members/nullnet-server/ui/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import { useApi } from '../hooks/useApi';
 import type { SessionJson } from '../types';
 import { useRef, useState, useEffect } from 'react';
 
-type Page = 'dashboard' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config' | 'certificates' | 'events';
+type Page = 'dashboard' | 'topology' | 'services' | 'nodes' | 'sessions' | 'pool' | 'config' | 'certificates' | 'events';
 
 interface Props {
   page: Page;
@@ -17,6 +17,7 @@ const NAV = [
     group: 'Overview',
     items: [
       { id: 'dashboard', icon: '⊞', label: 'Dashboard', to: '/' },
+      { id: 'topology', icon: '◎', label: 'Topology', to: '/topology' },
     ],
   },
   {

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
@@ -2,7 +2,14 @@ import { useTopologyData, useTopologyUI } from './TopologyContext';
 import TopologyGraphSvg from './TopologyGraphSvg';
 import ZoomFrame from './ZoomFrame';
 
-export default function TopologyGraph() {
+interface Props {
+  height?: number | string;
+  fill?: boolean;
+  anchor?: 'center' | 'top-left';
+  grow?: boolean;
+}
+
+export default function TopologyGraph({ height = 520, fill, anchor, grow }: Props) {
   const { graph } = useTopologyData();
   const {
     selectedNodeId,
@@ -16,7 +23,7 @@ export default function TopologyGraph() {
   if (!graph) return null;
 
   return (
-    <ZoomFrame height={520}>
+    <ZoomFrame height={height} fill={fill} anchor={anchor} grow={grow}>
       <TopologyGraphSvg
         graph={graph}
         selectedNodeId={selectedNodeId}

--- a/members/nullnet-server/ui/src/components/topology/ZoomFrame.tsx
+++ b/members/nullnet-server/ui/src/components/topology/ZoomFrame.tsx
@@ -10,23 +10,28 @@ interface ZoomState {
 }
 
 interface Props {
-  height: number;
+  height: number | string;
+  fill?: boolean;
+  anchor?: 'center' | 'top-left';
+  grow?: boolean;
   children: React.ReactNode;
 }
 
-function computeHome(cw: number, ch: number, contentH: number): ZoomState {
+function computeHome(cw: number, ch: number, contentH: number, anchor: 'center' | 'top-left'): ZoomState {
   let scale = 1, tx = 0, ty = 0;
   if (contentH > ch) {
     scale = (ch / contentH) * 0.9;
-    tx = (cw * (1 - scale)) / 2;
-    ty = (ch - contentH * scale) / 2;
-  } else {
+    if (anchor === 'center') {
+      tx = (cw * (1 - scale)) / 2;
+      ty = (ch - contentH * scale) / 2;
+    }
+  } else if (anchor === 'center') {
     ty = (ch - contentH) / 2;
   }
   return { scale, tx, ty };
 }
 
-export default function ZoomFrame({ height, children }: Props) {
+export default function ZoomFrame({ height, fill, anchor = 'center', grow, children }: Props) {
   const [zoom, setZoom] = useState<ZoomState>({ scale: 1, tx: 0, ty: 0 });
   const dragging = useRef<{ startX: number; startY: number; startTx: number; startTy: number } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -34,9 +39,9 @@ export default function ZoomFrame({ height, children }: Props) {
   const homeZoom = useRef<ZoomState>({ scale: 1, tx: 0, ty: 0 });
   const prevContentH = useRef(0);
 
-  // Initial centering before first paint — sets prevContentH so the ResizeObserver
-  // below skips its first fire (same size) and only re-fits on actual graph changes.
+  // Initial fit — skipped in grow mode (container sizes to content, no transform needed).
   useLayoutEffect(() => {
+    if (grow) return;
     const container = containerRef.current;
     const content = contentRef.current;
     if (!container || !content) return;
@@ -45,13 +50,14 @@ export default function ZoomFrame({ height, children }: Props) {
     const contentH = content.clientHeight;
     if (!contentH) return;
     prevContentH.current = contentH;
-    const home = computeHome(cw, ch, contentH);
+    const home = computeHome(cw, ch, contentH, anchor);
     homeZoom.current = home;
     setZoom(home);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Re-fit when the SVG grows or shrinks (new nodes added/removed, window resize).
+  // Re-fit when the SVG grows or shrinks — skipped in grow mode.
   useEffect(() => {
+    if (grow) return;
     const container = containerRef.current;
     const content = contentRef.current;
     if (!container || !content) return;
@@ -61,7 +67,7 @@ export default function ZoomFrame({ height, children }: Props) {
       prevContentH.current = contentH;
       const cw = container.clientWidth;
       const ch = container.clientHeight;
-      const home = computeHome(cw, ch, contentH);
+      const home = computeHome(cw, ch, contentH, anchor);
       homeZoom.current = home;
       setZoom(home);
     });
@@ -113,12 +119,12 @@ export default function ZoomFrame({ height, children }: Props) {
     Math.abs(zoom.ty - h.ty) < 0.5;
 
   return (
-    <div style={{ position: 'relative' }}>
+    <div style={{ position: 'relative', ...((fill && !grow) ? { height: '100%' } : {}) }}>
       <div
         ref={containerRef}
         style={{
-          height,
-          overflow: 'hidden',
+          height: grow ? 'auto' : height,
+          overflow: grow ? 'visible' : 'hidden',
           position: 'relative',
           cursor: dragging.current ? 'grabbing' : 'grab',
           userSelect: 'none',

--- a/members/nullnet-server/ui/src/pages/Dashboard.tsx
+++ b/members/nullnet-server/ui/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import Layout from '../components/Layout';
 import { useApi } from '../hooks/useApi';
 import { useStack } from '../StackContext';
@@ -9,9 +9,8 @@ import TopologyPanel from '../components/topology/TopologyPanel';
 
 function DashboardView() {
   const { stack } = useStack();
-  const { graph, sessions, chains } = useTopologyData();
+  const { graph, sessions, chains, services } = useTopologyData();
   const { panel, dispatch } = useTopologyUI();
-  const [connectionsOpen, setConnectionsOpen] = useState(true);
 
   const { data: nodes } = useApi<NodeJson[]>(`/api/nodes/${stack}`, 5000);
   const { data: pool } = useApi<PoolJson>('/api/pool', 5000);
@@ -32,154 +31,261 @@ function DashboardView() {
   const nodeCount = nodes?.length ?? 0;
   const edgeCount = graph?.edges.length ?? 0;
   const nodeCountG = graph?.nodes.length ?? 0;
+  const registeredCount = graph?.nodes.filter(n => n.registered).length ?? 0;
   const proxyCount = graph
     ? new Set(graph.edges.filter(e => e.via_proxy).map(e => e.via_proxy!)).size
     : 0;
   const poolPct = pool ? ((pool.in_use / pool.total) * 100).toFixed(1) : null;
 
+  // sorted: registered first, then alpha
+  const sortedNodes = useMemo(() => {
+    if (!graph) return [];
+    return [...graph.nodes].sort((a, b) => {
+      if (a.registered !== b.registered) return a.registered ? -1 : 1;
+      return a.id.localeCompare(b.id);
+    });
+  }, [graph]);
+
+  // look up max_networks from services context for the services card
+  const maxNetByName = useMemo(() => {
+    const m = new Map<string, number | undefined>();
+    for (const s of services ?? []) m.set(s.name, s.max_networks);
+    return m;
+  }, [services]);
+
   return (
     <>
       <div className="content">
+        {/* 3 rows: stats (auto) | info section (220px) | topology (auto, grows with content) */}
+        <div style={{ display: 'grid', gridTemplateRows: 'auto 220px auto', gap: 12 }}>
 
-        {/* Active Connections — always-visible collapsible card with stats in header */}
-        <div className="card glass" style={{ marginBottom: 12 }}>
-          <div
-            className="card-head"
-            onClick={() => setConnectionsOpen(v => !v)}
-            style={{ cursor: 'pointer', userSelect: 'none' }}
-          >
-            <span className="card-label">Active Connections</span>
-            <span style={{ display: 'flex', gap: 14, alignItems: 'center', fontSize: 10, color: 'var(--t2)' }}>
-              <span>
-                <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)', marginRight: 4 }}>{sessionCount}</span>
-                sessions
-              </span>
-              <span style={{ color: 'var(--t3)' }}>·</span>
-              <span>
-                <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--green)', marginRight: 4 }}>{nodeCount}</span>
-                nodes
-              </span>
-              <span style={{ color: 'var(--t3)' }}>·</span>
-              <span>
-                <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--blue)', marginRight: 4 }}>{edgeCount}</span>
-                edges
-              </span>
-              {poolPct !== null && (
-                <>
-                  <span style={{ color: 'var(--t3)' }}>·</span>
-                  <span>
-                    <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t1)', marginRight: 4 }}>{poolPct}%</span>
-                    pool
-                  </span>
-                </>
-              )}
-              <span style={{ fontSize: 11, lineHeight: 1, marginLeft: 2 }}>{connectionsOpen ? '▾' : '▸'}</span>
-            </span>
+          {/* ── Row 1: stat cards ── */}
+          <div className="stats" style={{ marginBottom: 0 }}>
+            <div className="stat glass">
+              <div className="stat-label">Sessions</div>
+              <div className="stat-value" style={{ color: 'var(--cyan)' }}>{sessionCount}</div>
+              <div className="stat-sub">active sessions</div>
+            </div>
+            <div className="stat glass">
+              <div className="stat-label">Services</div>
+              <div className="stat-value">
+                {registeredCount}<span className="denom">/{nodeCountG}</span>
+              </div>
+              <div className="stat-sub">{nodeCountG - registeredCount} unregistered</div>
+            </div>
+            <div className="stat glass">
+              <div className="stat-label">Pool</div>
+              <div className="stat-value" style={{ color: poolPct && parseFloat(poolPct) > 80 ? 'var(--amber)' : 'var(--t0)' }}>
+                {poolPct !== null ? `${poolPct}%` : '—'}
+              </div>
+              <div className="stat-sub">{pool ? `${pool.in_use} / ${pool.total} in use` : 'loading…'}</div>
+            </div>
+            <div className="stat glass">
+              <div className="stat-label">Nodes</div>
+              <div className="stat-value" style={{ color: 'var(--green)' }}>{nodeCount}</div>
+              <div className="stat-sub">connected</div>
+            </div>
           </div>
 
-          {connectionsOpen && (
-            edgeCount === 0 ? (
-              <div style={{ padding: '20px 18px', color: 'var(--t2)', fontSize: 11, textAlign: 'center' }}>
-                No active connections
+          {/* ── Row 2: connections + services ── */}
+          <div style={{ display: 'flex', gap: 12, minHeight: 0 }}>
+
+            {/* Active connections */}
+            <div className="card glass" style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', marginBottom: 0 }}>
+              <div className="card-head">
+                <span className="card-label">Active Connections</span>
+                <span style={{ display: 'flex', gap: 10, alignItems: 'center', fontSize: 10, color: 'var(--t2)' }}>
+                  <span>
+                    <span style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--blue)', marginRight: 4 }}>{edgeCount}</span>
+                    edges
+                  </span>
+                  {proxyCount > 0 && (
+                    <>
+                      <span style={{ color: 'var(--t3)' }}>·</span>
+                      <span style={{ color: '#fbbf24' }}>{proxyCount} via proxy</span>
+                    </>
+                  )}
+                </span>
               </div>
-            ) : (
-              <table className="tbl">
-                <thead>
-                  <tr>
-                    <th>From</th>
-                    <th>Via Proxy</th>
-                    <th>To</th>
-                    <th>Net ID</th>
-                    <th>Client Net</th>
-                    <th>Server Net</th>
-                    <th>Setup</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {graph!.edges.map((e, i) => {
-                    const session = sessionByNetId.get(e.net_id);
+              <div style={{ flex: 1, overflowY: 'auto' }}>
+                {edgeCount === 0 ? (
+                  <div style={{ padding: '20px 18px', color: 'var(--t2)', fontSize: 11, textAlign: 'center' }}>
+                    No active connections
+                  </div>
+                ) : (
+                  <table className="tbl">
+                    <thead>
+                      <tr>
+                        <th>From</th>
+                        <th>Via Proxy</th>
+                        <th>To</th>
+                        <th>Net ID</th>
+                        <th>Client Net</th>
+                        <th>Server Net</th>
+                        <th>Setup</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {graph!.edges.map((e, i) => {
+                        const session = sessionByNetId.get(e.net_id);
+                        return (
+                          <tr
+                            key={i}
+                            onClick={() => dispatch({ type: 'EDGE_CLICKED', fromId: e.from, toId: e.to, edgeIndices: [i] })}
+                            style={{
+                              cursor: 'pointer',
+                              background: panel?.type === 'edge' && panel.edgeIndices.includes(i)
+                                ? 'rgba(91,156,246,.07)'
+                                : undefined,
+                            }}
+                          >
+                            <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.from}</td>
+                            <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: '#fbbf24' }}>
+                              {e.via_proxy ?? <span style={{ color: 'var(--t3)' }}>—</span>}
+                            </td>
+                            <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.to}</td>
+                            <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
+                              {e.via_proxy && chainByProxyNetId.has(e.net_id)
+                                ? chainByProxyNetId.get(e.net_id)!.join(', ')
+                                : e.net_id}
+                            </td>
+                            <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: 'var(--t1)' }}>
+                              {session?.client_net ?? <span style={{ color: 'var(--t3)' }}>—</span>}
+                            </td>
+                            <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: 'var(--t1)' }}>
+                              {session?.server_net ?? <span style={{ color: 'var(--t3)' }}>—</span>}
+                            </td>
+                            <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
+                              {e.setup_ms > 0 ? `${e.setup_ms}ms` : '—'}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </div>
+
+            {/* Services status */}
+            <div className="card glass" style={{ width: 300, flexShrink: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden', marginBottom: 0 }}>
+              <div className="card-head">
+                <span className="card-label">Services</span>
+                <span style={{ fontSize: 10, color: 'var(--t2)' }}>
+                  {registeredCount} / {nodeCountG} registered
+                </span>
+              </div>
+              <div style={{ flex: 1, overflowY: 'auto' }}>
+                {sortedNodes.length === 0 ? (
+                  <div style={{ padding: '20px 18px', color: 'var(--t2)', fontSize: 11, textAlign: 'center' }}>
+                    No services
+                  </div>
+                ) : (
+                  sortedNodes.map(node => {
+                    const isHealthy = node.registered && node.active_replica_count > 0 && node.paused_replica_count === 0;
+                    const isDegraded = node.registered && (node.active_replica_count === 0 || node.paused_replica_count > 0);
+                    const dotColor = isHealthy ? 'var(--green)' : isDegraded ? 'var(--amber)' : 'var(--red)';
+                    const dotGlow = isHealthy
+                      ? '0 0 5px rgba(52,211,153,.7)'
+                      : isDegraded
+                        ? '0 0 5px rgba(251,191,36,.7)'
+                        : '0 0 5px rgba(248,113,113,.7)';
+                    const maxNet = maxNetByName.get(node.id);
+                    const activeSessions = graph!.edges.filter(e => e.from === node.id || e.to === node.id).length;
+
                     return (
-                      <tr
-                        key={i}
-                        onClick={() => dispatch({ type: 'EDGE_CLICKED', fromId: e.from, toId: e.to, edgeIndices: [i] })}
+                      <div
+                        key={node.id}
+                        onClick={() => dispatch({ type: 'NODE_CLICKED', nodeId: node.id })}
                         style={{
+                          display: 'flex', alignItems: 'center', gap: 10,
+                          padding: '9px 16px',
+                          borderBottom: '1px solid rgba(255,255,255,.03)',
                           cursor: 'pointer',
-                          background: panel?.type === 'edge' && panel.edgeIndices.includes(i)
+                          background: panel?.type === 'node' && panel.nodeId === node.id
                             ? 'rgba(91,156,246,.07)'
                             : undefined,
+                          transition: 'background .12s',
                         }}
+                        onMouseEnter={e => { if (!(panel?.type === 'node' && panel.nodeId === node.id)) (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,.025)'; }}
+                        onMouseLeave={e => { if (!(panel?.type === 'node' && panel.nodeId === node.id)) (e.currentTarget as HTMLElement).style.background = ''; }}
                       >
-                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.from}</td>
-                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: '#fbbf24' }}>
-                          {e.via_proxy ?? <span style={{ color: 'var(--t3)' }}>—</span>}
-                        </td>
-                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.to}</td>
-                        <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
-                          {e.via_proxy && chainByProxyNetId.has(e.net_id)
-                            ? chainByProxyNetId.get(e.net_id)!.join(', ')
-                            : e.net_id}
-                        </td>
-                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: 'var(--t1)' }}>
-                          {session?.client_net ?? <span style={{ color: 'var(--t3)' }}>—</span>}
-                        </td>
-                        <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: 'var(--t1)' }}>
-                          {session?.server_net ?? <span style={{ color: 'var(--t3)' }}>—</span>}
-                        </td>
-                        <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
-                          {e.setup_ms > 0 ? `${e.setup_ms}ms` : '—'}
-                        </td>
-                      </tr>
+                        <span style={{ width: 6, height: 6, borderRadius: '50%', background: dotColor, boxShadow: dotGlow, flexShrink: 0 }} />
+                        <span style={{ flex: 1, fontSize: 12, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {node.id}
+                        </span>
+                        {node.entry_point && (
+                          <span style={{ fontSize: 9, padding: '1px 6px', borderRadius: 20, background: 'rgba(167,139,250,.12)', border: '1px solid rgba(167,139,250,.25)', color: 'var(--purple)', flexShrink: 0, letterSpacing: '.04em' }}>
+                            EP
+                          </span>
+                        )}
+                        <span style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 10, color: 'var(--t2)', flexShrink: 0 }}>
+                          {node.active_replica_count}
+                          {maxNet !== undefined
+                            ? <span style={{ color: 'var(--t3)' }}>/{maxNet}</span>
+                            : <span style={{ color: 'var(--t3)' }}>/{node.replica_count}</span>
+                          }
+                        </span>
+                        {activeSessions > 0 && (
+                          <span style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 9, color: 'var(--cyan)', flexShrink: 0 }}>
+                            {activeSessions}↔
+                          </span>
+                        )}
+                      </div>
                     );
-                  })}
-                </tbody>
-              </table>
-            )
-          )}
-        </div>
+                  })
+                )}
+              </div>
+            </div>
 
-        {/* Full-width topology card */}
-        <div className="card glass">
-          <div className="card-head">
-            <span className="card-label">Service Topology</span>
-            <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', gap: 10, alignItems: 'center' }}>
-              {graph ? (
-                <>
-                  <span>{nodeCountG} services</span>
-                  {proxyCount > 0 && <span style={{ color: '#fbbf24' }}>{proxyCount} prox{proxyCount === 1 ? 'y' : 'ies'}</span>}
-                  <span>{edgeCount} edges</span>
-                </>
-              ) : 'loading…'}
-            </span>
           </div>
 
-          <div style={{ background: 'rgba(0,0,0,.25)' }}>
-            {!graph && (
-              <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
-                loading topology…
-              </div>
-            )}
-            {graph && graph.nodes.length === 0 && (
-              <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
-                No services registered for stack <b>{stack}</b>
-              </div>
-            )}
-            {graph && graph.nodes.length > 0 && <TopologyGraph />}
-          </div>
-
-          {proxyCount > 0 && (
-            <div style={{ padding: '8px 14px 10px', display: 'flex', gap: 16, fontSize: 10, color: 'var(--t2)', borderTop: '1px solid var(--gb)' }}>
-              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                <span style={{ width: 20, height: 1.5, background: 'rgba(255,255,255,.25)', display: 'inline-block' }} />
-                direct
-              </span>
-              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                <span style={{ width: 20, height: 1.5, display: 'inline-block', backgroundImage: 'repeating-linear-gradient(90deg,rgba(251,191,36,.45) 0,rgba(251,191,36,.45) 4px,transparent 4px,transparent 7px)' }} />
-                via proxy
+          {/* ── Row 3: topology grows to fit content ── */}
+          <div className="card glass" style={{ marginBottom: 0 }}>
+            <div className="card-head">
+              <span className="card-label">Service Topology</span>
+              <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', gap: 10, alignItems: 'center' }}>
+                {graph ? (
+                  <>
+                    <span>{nodeCountG} services</span>
+                    {proxyCount > 0 && <span style={{ color: '#fbbf24' }}>{proxyCount} prox{proxyCount === 1 ? 'y' : 'ies'}</span>}
+                    <span>{edgeCount} edges</span>
+                  </>
+                ) : 'loading…'}
               </span>
             </div>
-          )}
-        </div>
 
+            <div style={{ background: 'rgba(0,0,0,.25)' }}>
+              {!graph && (
+                <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
+                  loading topology…
+                </div>
+              )}
+              {graph && graph.nodes.length === 0 && (
+                <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
+                  No services registered for stack <b>{stack}</b>
+                </div>
+              )}
+              {graph && graph.nodes.length > 0 && (
+                <TopologyGraph grow anchor="top-left" />
+              )}
+            </div>
+
+            {proxyCount > 0 && (
+              <div style={{ padding: '8px 14px 10px', display: 'flex', gap: 16, fontSize: 10, color: 'var(--t2)', borderTop: '1px solid var(--gb)' }}>
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                  <span style={{ width: 20, height: 1.5, background: 'rgba(255,255,255,.25)', display: 'inline-block' }} />
+                  direct
+                </span>
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                  <span style={{ width: 20, height: 1.5, display: 'inline-block', backgroundImage: 'repeating-linear-gradient(90deg,rgba(251,191,36,.45) 0,rgba(251,191,36,.45) 4px,transparent 4px,transparent 7px)' }} />
+                  via proxy
+                </span>
+              </div>
+            )}
+          </div>
+
+        </div>
       </div>
 
       <TopologyPanel />

--- a/members/nullnet-server/ui/src/pages/Topology.tsx
+++ b/members/nullnet-server/ui/src/pages/Topology.tsx
@@ -1,140 +1,32 @@
-import { useMemo } from 'react';
 import Layout from '../components/Layout';
 import { useStack } from '../StackContext';
-import { TopologyProvider, useTopologyData, useTopologyUI } from '../components/topology/TopologyContext';
+import { TopologyProvider, useTopologyData } from '../components/topology/TopologyContext';
 import TopologyGraph from '../components/topology/TopologyGraph';
 import TopologyPanel from '../components/topology/TopologyPanel';
 
 function TopologyView() {
-  const { graph, chains } = useTopologyData();
-  const { panel, dispatch } = useTopologyUI();
-
-  const chainByProxyNetId = useMemo(() => {
-    const m = new Map<number, number[]>();
-    for (const c of chains ?? []) m.set(c.proxy_net_id, c.all_net_ids);
-    return m;
-  }, [chains]);
+  const { graph } = useTopologyData();
   const { stack } = useStack();
 
-  const nodeCount = graph?.nodes.length ?? 0;
-  const registeredCount = graph?.nodes.filter(n => n.registered).length ?? 0;
-  const edgeCount = graph?.edges.length ?? 0;
-  const proxyCount = graph
-    ? new Set(graph.edges.filter(e => e.via_proxy).map(e => e.via_proxy!)).size
-    : 0;
+  if (!graph) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 'calc(100vh - 48px)', color: 'var(--t2)', fontSize: 11 }}>
+        loading topology…
+      </div>
+    );
+  }
+
+  if (graph.nodes.length === 0) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 'calc(100vh - 48px)', color: 'var(--t2)', fontSize: 11 }}>
+        No services registered for stack <b>{stack}</b>
+      </div>
+    );
+  }
 
   return (
     <>
-      <div className="content">
-        <div className="stats">
-          <div className="stat glass">
-            <div className="stat-label">Services</div>
-            <div className="stat-value">{registeredCount}<span className="denom">/{nodeCount}</span></div>
-            <div className="stat-sub">{nodeCount - registeredCount} unregistered</div>
-          </div>
-          <div className="stat glass">
-            <div className="stat-label">Active Edges</div>
-            <div className="stat-value" style={{ color: 'var(--cyan)' }}>{edgeCount}</div>
-            <div className="stat-sub">live connections</div>
-          </div>
-          <div className="stat glass">
-            <div className="stat-label">Entry Points</div>
-            <div className="stat-value" style={{ color: 'var(--green)' }}>
-              {graph?.nodes.filter(n => n.entry_point).length ?? '—'}
-            </div>
-            <div className="stat-sub">with timeout</div>
-          </div>
-        </div>
-
-
-        <div className="card glass">
-          <div className="card-head">
-            <span className="card-label">Service Topology</span>
-            <span style={{ fontSize: 10, color: 'var(--t2)', display: 'flex', gap: 10 }}>
-              {graph ? (
-                <>
-                  <span>{nodeCount} services</span>
-                  {proxyCount > 0 && <span style={{ color: '#fbbf24' }}>{proxyCount} prox{proxyCount === 1 ? 'y' : 'ies'}</span>}
-                  <span>{edgeCount} edges</span>
-                </>
-              ) : 'loading…'}
-            </span>
-          </div>
-          <div style={{ background: 'rgba(0,0,0,.25)', padding: 0 }}>
-            {!graph && (
-              <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
-                loading topology…
-              </div>
-            )}
-            {graph && graph.nodes.length === 0 && (
-              <div style={{ color: 'var(--t2)', fontSize: 11, padding: '40px 0', textAlign: 'center' }}>
-                No services registered for stack <b>{stack}</b>
-              </div>
-            )}
-            {graph && graph.nodes.length > 0 && <TopologyGraph />}
-          </div>
-          {proxyCount > 0 && (
-            <div style={{ padding: '8px 14px 10px', display: 'flex', gap: 16, fontSize: 10, color: 'var(--t2)', borderTop: '1px solid var(--gb)' }}>
-              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                <span style={{ width: 20, height: 1.5, background: 'rgba(255,255,255,.25)', display: 'inline-block' }} />
-                direct
-              </span>
-              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                <span style={{ width: 20, height: 1.5, display: 'inline-block', backgroundImage: 'repeating-linear-gradient(90deg, rgba(251,191,36,.45) 0, rgba(251,191,36,.45) 4px, transparent 4px, transparent 7px)' }} />
-                via proxy
-              </span>
-            </div>
-          )}
-        </div>
-
-        {graph && graph.edges.length > 0 && (
-          <div className="card glass" style={{ marginTop: 12 }}>
-            <div className="card-head">
-              <span className="card-label">Active Connections</span>
-            </div>
-            <table className="tbl">
-              <thead>
-                <tr>
-                  <th>From</th>
-                  <th>Via Proxy</th>
-                  <th>To</th>
-                  <th>Net ID</th>
-                  <th>Setup</th>
-                </tr>
-              </thead>
-              <tbody>
-                {graph.edges.map((e, i) => (
-                  <tr
-                    key={i}
-                    onClick={() => dispatch({ type: 'EDGE_CLICKED', fromId: e.from, toId: e.to, edgeIndices: [i] })}
-                    style={{
-                      cursor: 'pointer',
-                      background: panel?.type === 'edge' && panel.edgeIndices.includes(i)
-                        ? 'rgba(91,156,246,.07)'
-                        : undefined,
-                    }}
-                  >
-                    <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.from}</td>
-                    <td style={{ fontFamily: "'JetBrains Mono',monospace", fontSize: 11, color: '#fbbf24' }}>
-                      {e.via_proxy ?? <span style={{ color: 'var(--t3)' }}>—</span>}
-                    </td>
-                    <td style={{ fontFamily: "'JetBrains Mono',monospace", fontWeight: 500 }}>{e.to}</td>
-                    <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--cyan)' }}>
-                      {e.via_proxy && chainByProxyNetId.has(e.net_id)
-                        ? chainByProxyNetId.get(e.net_id)!.join(', ')
-                        : e.net_id}
-                    </td>
-                    <td style={{ fontFamily: "'JetBrains Mono',monospace", color: 'var(--t2)', fontSize: 11 }}>
-                      {e.setup_ms > 0 ? `${e.setup_ms}ms` : '—'}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-
+      <TopologyGraph height="calc(100vh - 48px)" />
       <TopologyPanel />
     </>
   );
@@ -144,7 +36,7 @@ export default function Topology() {
   const { stack } = useStack();
   return (
     <Layout
-      page="dashboard"
+      page="topology"
       topbarRight={
         <span style={{ fontSize: 11, color: 'var(--t1)', display: 'flex', alignItems: 'center', gap: 5 }}>
           <span className="live-dot" />live · SSE


### PR DESCRIPTION

**New `/topology` route — diagram only**

The existing topology page had stat cards, a card header, and an active connections table below the graph. It's now stripped to a single full-viewport diagram with nothing else on screen. The graph is centered and scales to fit the viewport height minus the topbar. The slide-in detail panel (node/edge/internet) still opens on click. A "Topology" nav entry has been added under Overview in the sidebar.

**Dashboard — three-section layout**

The dashboard was previously a collapsible connections card stacked above the topology card. It has been restructured into a three-row CSS grid:

1. **Stat cards** — four glass cards showing Sessions (cyan), Services registered/total, Pool % (turns amber above 80%), and Nodes connected. All values come from data already fetched by `TopologyProvider` and the existing `useApi` calls — no new endpoints.

2. **Info section (220 px fixed)** — two side-by-side cards:
   - *Active Connections* — the existing edge table (From / Via Proxy / To / Net ID / Client Net / Server Net / Setup), now scrollable within the fixed height.
   - *Services* (300 px) — a compact list of every service node sorted registered-first then alphabetically. Each row shows a status dot (green = healthy, amber = degraded/paused replicas, red = unregistered), service name, replica count (active / max_networks or total), an "EP" badge for entry points, and a `↔` count for services with active edges. Clicking a row opens the topology panel for that node.

3. **Topology card** — anchored to top-left, no scale-to-fit; the card grows with the SVG's natural aspect ratio and the page scrolls if the graph is taller than the viewport.
