### PR TITLE
Scope backend triggers by container instead of port alone

### DIFF
--- a/docs/net-id-reuse-races.md
+++ b/docs/net-id-reuse-races.md
@@ -1,0 +1,229 @@
+# Net-id reuse races
+
+Status: **open**. Written 2026-08-05, after the same-host MACsec ghost-SCI bug
+(PR #145) was root-caused to net-id reuse churn.
+
+Read this before re-enabling `timeout` on any stack. instaprotek currently runs
+with all timeouts at `0` specifically to keep the reaper from driving this churn.
+
+## Why this exists
+
+A net id is the *only* thing that names an edge's kernel artifacts. Nothing
+distinguishes one generation of an id from the next, so a teardown belonging to
+generation N can delete generation N+1's devices. PR #145 fixed the resulting
+*mis-keying* (deterministic MACs) and the mid-flight *interleave* (per-net-id
+flock), but not the *ordering*.
+
+Expect the failure mode to shift from "ghost SCI, silent black hole" to
+"missing edge, silent black hole". Same symptom for users — a hang until the
+caller's own timeout, surfacing as an opaque 5xx — different forensic signature.
+
+## The races
+
+### A. The id is freed on enqueue, not on completion
+
+`orchestrator.rs:665-678`. Both teardown messages are sent fire-and-forget
+(`let _ = outbound.send(...)`), then `free(net_id)` runs immediately. There is
+no ack. Contrast `send_container_resume` (`orchestrator.rs:601-606`), which
+waits on a `pending` entry with a 30 s timeout.
+
+The id is therefore reallocatable before the client has dequeued the message.
+
+### B. The client executes messages concurrently
+
+`control_channel.rs:71-127` `tokio::spawn`s every inbound message. gRPC
+guarantees arrival order, not completion order, so teardown(N) and setup(N) can
+be in flight at the same time.
+
+### C. No generation marker anywhere
+
+Every artifact derives from the net id alone:
+
+    br_<id>_<s|c>   veth-<id>-s/c   macsec-<id>-s/c
+    MACs 02:0X:<id> (PR #145)       SPI <id>+1000    /var/lock/nullnet-net-<id>.lock
+
+Generation N and N+1 are indistinguishable to the kernel. This is what makes
+A+B destructive rather than merely wasteful.
+
+### D. The dstport is freed in the same breath
+
+`orchestrator.rs:679-683`. A late teardown can delete a *new* tunnel's XFRM
+policy on a reused port — slightly likelier since PR #145 matches policies on
+dport rather than endpoints.
+
+## `timeout = 0` is a partial mitigation
+
+It does stop the reaper: `timeout.rs:76-78` (`collect_timed_out_clients`) and
+`timeout.rs:101-103` (`nearest_timeout`) both skip services with `timeout == 0`,
+so no proxy client ever expires.
+
+It does **not** stop net-id reuse. These paths still free ids:
+
+- `changes.rs:316` `teardown_chain`, `changes.rs:472,545` `decrement_chain` —
+  config changes, including live edits via the Config UI
+- `nullnet_grpc_impl.rs:1498` — chain decrement on deregistration
+- `orchestrator.rs:431,472` — node disconnect, missing containers
+
+A container restart or a config reload still recycles an id.
+
+## Agreed work plan (2026-08-05)
+
+Five items, to be done over the next days, before re-enabling timeouts.
+
+**(a) FIFO allocation — both pools.** `net_id_pool.rs:43` takes
+`freed.iter().next()`, the lowest freed id, which in practice is the one freed
+most recently — the worst case. A `VecDeque` popped from the front maximizes the
+gap between free and reuse. **`UdpPortPool::allocate` (`:104-107`) has the same
+pattern and needs the same change**, or half the reuse pressure remains.
+Near-trivial, strictly helps, no protocol change.
+
+**(b) Quarantine freed ids** for a few seconds via a timestamped delay queue.
+Narrows the window further without a protocol change. Becomes redundant once (c)
+lands — treat it as a stopgap only if (c) slips.
+
+**(c) Ack the teardown before freeing**, mirroring the `ContainerResume` pattern
+at `orchestrator.rs:601-606`. Also covers the case (a)/(b) provably cannot: when
+the destination client is not connected, `send_net_teardown` sends *nothing*
+(`:669-670`) and frees the id anyway, so the old edge stays live in the kernel
+and the next allocation of that id collides with it.
+
+**(d) Serialize per net id on the client** — a per-id task queue instead of the
+blanket `tokio::spawn` at `control_channel.rs:71-127`. gRPC already preserves
+order within a stream, so the messages *arrive* teardown-then-setup; the spawn is
+the only thing destroying that order. Self-contained, no protocol change. Kills
+both the teardown-vs-setup and teardown-vs-suspend races on the common path, and
+extends the PR #145 flock (which covers only the shell scripts) to the Rust-side
+state — triggers, host mappings, firewall maps.
+
+Caveat for (d): strict per-id ordering means a slow teardown blocks that id's
+next setup rather than overlapping it. Correct, but it serializes work that is
+currently parallel — so land the hosts fix below at the same time, since the
+`docker exec` in `remove_host_mapping` is exactly the kind of long blocking call
+that would then sit in the critical path.
+
+**(e) Direct hosts-file writes** — see "Stale state left on containers" below.
+Rewrite `container_hosts` / `write_container_hosts` / `running_containers` in
+`host_mappings.rs` to edit `/var/lib/docker/containers/<id>/hosts` directly and
+enumerate with `docker ps -aq`.
+
+Minimum before tight timeouts: **a + d + e**. Then **c**. Skip **b** if **c**
+lands.
+
+### Not covered by any of the above
+
+These five make reuse *correct*, not *cheap*. A tight timeout with heavy client
+churn is a separate axis, untested: the timeout must comfortably exceed real
+setup latency (measured `setup_ms` 1,050-7,139 on instaprotek, plus the client's
+10 s `declare_services` poll) or edges expire while still being built;
+`nearest_timeout` caps the reaper's poll interval by the tightest configured
+timeout (`timeout.rs:108`); pause/resume can flap if edges expire faster than
+the 30 s resume ack; and `max_networks` is enforced per service
+(`nullnet_grpc_impl.rs:374`, emits `MaxNetworksLimitEnforced`). Roll the timeout
+down in stages and watch the event stream.
+
+## Stale state left on containers
+
+Separate defect from the races above, same class of outage: a container holding
+a mapping or an interface for an edge that no longer exists resolves a name to a
+dead overlay IP, which is *strictly worse* than falling through to public DNS
+(see the comment at `host_mappings.rs:76-78`). Silent hang, no error.
+
+### What is already covered
+
+`cleanup_network` (`commands/mod.rs:127-142`) runs on every client start, in a
+deliberate order — host links, then XFRM by SPI range, then `/etc/hosts`, then
+egress steers (XFRM strictly after links, or a tunnel would briefly run
+unencrypted).
+
+- Host links: `vxlan_cleanup_network` (`:454`) sweeps `vxlan-*`, `ns_*-out`,
+  `veth-*`, `br_*`.
+- `macsec-*` is not swept by name, but it is a child of `veth-*`, so deleting
+  the veth cascades. Same for the container-side `ns_<id>_*-in` end: veth pairs
+  die together, so no in-container link sweep is needed.
+- Only lines ending in `HOSTS_MARKER` (`# nullnet`) are removed, never the
+  operator's own entries.
+
+### The gap: containers that cannot be `docker exec`'d
+
+`purge_stale_mappings` reaches each container through `docker exec`
+(`host_mappings.rs:140-145`), and `container_hosts` returns `None` on any
+non-success status, so the loop skips that container and leaves its entries.
+
+- **Paused containers** still appear in `docker ps -q`, so they are enumerated,
+  but Docker refuses `exec` into a paused container — so they are silently
+  skipped. instaprotek runs `redis`, `website`, `register-v2` and
+  `mobile-api-v2` paused, and on resume each would hold a mapping to a tunnel
+  that no longer exists.
+- **Stopped containers** are excluded from `docker ps -q` outright. Mostly
+  harmless under Swarm, where a replacement task gets a fresh `/etc/hosts`, but
+  a plain `docker restart` preserves the file.
+
+VERIFIED on 103, 2026-08-05:
+
+    docker ps -q  --filter name=pausetest | wc -l   -> 1   (enumerated)
+    docker ps -aq --filter name=pausetest | wc -l   -> 1
+    docker exec pausetest cat /etc/hosts
+      -> Error response from daemon: Container pausetest is paused,
+         unpause the container before exec        (rc=1, so silently skipped)
+    /var/lib/docker/containers/<id>/hosts          -> exists, readable while paused
+
+### It is not only the startup purge — it is every teardown
+
+`handle_vxlan_teardown` removes the mapping through the same `docker exec` path
+(`control_channel.rs:677-680` → `remove_host_mapping`). So a paused container
+strands its entry on the normal per-edge teardown too, not just on a restart.
+
+Worse, this races with pause/resume by design. `decrement_chain`
+(`service_info.rs:484-494`) calls `send_net_teardown` and then
+`reconcile_suspend` — both fire-and-forget, no ack — and the client spawns each
+inbound message in its own task (`control_channel.rs:71-127`), so ordering is
+not guaranteed. The pause fires exactly when the last client goes away, which is
+exactly when the teardown fires. If the suspend wins, the hosts entry is
+stranded. This is the common path, not a corner case.
+
+### Fix
+
+Edit the file directly instead of going through `exec`. A container's hosts file
+lives at `/var/lib/docker/containers/<id>/hosts` on the host and is bind-mounted
+in, so writing it there works for running, paused and stopped containers alike,
+and removes the per-container `docker exec` round trip that the lock comment at
+`host_mappings.rs:24-25` is working around. Enumerate with `docker ps -aq`.
+
+Contained to `container_hosts` / `write_container_hosts` / `running_containers`.
+
+### Audited and clean (2026-08-05)
+
+- **ipset trigger ports** — `nfqueue::init` does `ipset create -exist` then
+  `ipset flush` (`commands/nfqueue.rs:25-37`) on every client start, and the set
+  is repopulated from the server's config response. Per-edge changes go through
+  the diff in `apply_port_diff`. Nothing stale survives.
+- **eBPF maps** — no pinning anywhere in the tree (`EbpfLoader::new()` with no
+  `map_pin_path`, no `/sys/fs/bpf` references). The maps live inside the `Ebpf`
+  handle held by `Firewall`; dropping it on exit detaches the program and frees
+  them, so a restart always starts empty. Per-edge removal is refcounted:
+  `firewall_peers.remove` / `firewall_vxlan_ports.remove`
+  (`control_channel.rs:651-653`).
+- **conntrack** — an earlier note in this doc claimed nothing flushes it on
+  teardown. That was wrong. `dnat::init` runs a full `conntrack -F` at startup
+  (`commands/dnat.rs:25`), and `dnat::remove` calls `flush_conntrack(port)` per
+  proto on every edge teardown (`commands/dnat.rs:47-49`, reached from
+  `control_channel.rs:664-666`).
+- **`/var/lock/nullnet-net-<id>.lock`** (added by PR #145) — one empty file per
+  net id ever used, in tmpfs, cleared on reboot. Cosmetic; unbounded only within
+  a single uptime.
+
+So the `/etc/hosts`-via-`docker exec` path above is the one confirmed dirty
+case. Everything else that writes per-edge state either flushes wholesale at
+startup or is removed per edge on teardown.
+
+## Detecting it in the field
+
+`members/nullnet-client/vxlan_scripts/audit-macsec-sci.sh` — read-only, no sudo.
+Validated on 103: clean on a healthy edge, and it catches a planted ghost
+(which also reproduces the silent-drop symptom, confirming the causal half).
+`NO_PEER` is expected and harmless for cross-host edges, whose peer macsec lives
+on the other node.
+
+Related: `docs/uniform-edge-liveness-plan.md` — an edge that never passed a
+packet should not be reported as established, which is the reason all of this
+stayed invisible for four days.

--- a/members/nullnet-client/src/main.rs
+++ b/members/nullnet-client/src/main.rs
@@ -10,6 +10,7 @@ use crate::forward::receive::receive;
 use crate::forward::send::send;
 use crate::host_mappings::HostMappingsState;
 use crate::local_endpoints::LocalEndpoints;
+use crate::nfqueue::{TriggerMap, TriggerOwner};
 use crate::peers::peer::Peers;
 use crate::triggers::TriggersState;
 use clap::Parser;
@@ -161,7 +162,7 @@ async fn main() -> Result<(), Error> {
     // packet of each new watched-port flow, listener fires backend_trigger
     // with the resolved initiator container, waits for VxlanSetup to install
     // DNAT, then verdicts ACCEPT so the original packet hits the new chain.
-    let (config_tx, config_rx) = tokio::sync::mpsc::unbounded_channel::<HashMap<u16, String>>();
+    let (config_tx, config_rx) = tokio::sync::mpsc::unbounded_channel::<TriggerMap>();
 
     // Poked by the cache's docker-events watcher after every container
     // start/die so `declare_services` re-runs immediately instead of
@@ -181,8 +182,8 @@ async fn main() -> Result<(), Error> {
         policy_verdicts,
     );
 
-    // declare services + push the port→service map to the NFQUEUE listener
-    // on each refresh.
+    // declare services + push the port→trigger-owners map to the NFQUEUE
+    // listener on each refresh.
     tokio::spawn(async move {
         declare_services(grpc_server, config_tx, docker_changed)
             .await
@@ -291,7 +292,7 @@ async fn grpc_init() -> Result<NullnetGrpcInterface, Error> {
 
 async fn declare_services(
     grpc_server: NullnetGrpcInterface,
-    config_tx: UnboundedSender<HashMap<u16, String>>,
+    config_tx: UnboundedSender<TriggerMap>,
     docker_changed: Arc<Notify>,
 ) -> Result<(), Error> {
     let mut last_snapshot: Vec<String> = Vec::new();
@@ -370,17 +371,22 @@ async fn declare_services(
                     });
                 }
 
-                let mut port_to_service: HashMap<u16, String> = HashMap::new();
+                // One port may be claimed by several services on this node, so
+                // each maps to a list of owners rather than a single service.
+                let mut trigger_owners: TriggerMap = HashMap::new();
                 for st in response.service_triggers {
                     for port in st.ports {
                         let Ok(port) = u16::try_from(port) else {
                             eprintln!("server returned invalid trigger port {port}; skipping");
                             continue;
                         };
-                        port_to_service.insert(port, st.service_name.clone());
+                        trigger_owners.entry(port).or_default().push(TriggerOwner {
+                            service: st.service_name.clone(),
+                            containers: st.containers.clone(),
+                        });
                     }
                 }
-                if config_tx.send(port_to_service).is_err() {
+                if config_tx.send(trigger_owners).is_err() {
                     // observer task gone; nothing more to do here
                     return Ok(());
                 }

--- a/members/nullnet-client/src/nfqueue/listener.rs
+++ b/members/nullnet-client/src/nfqueue/listener.rs
@@ -32,12 +32,42 @@ const TRIGGER_TIMEOUT: Duration = Duration::from_secs(5);
 /// giving up on the held packet.
 const ACTIVE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// A service that declared a trigger on a port, and the containers on this node
+/// that host it.
+#[derive(Debug, Clone)]
+pub struct TriggerOwner {
+    pub service: String,
+    /// Real container names, matching the bridge-IP cache's string space. Empty
+    /// means a server predating `ServiceTrigger.containers`, in which case the
+    /// owner matches any container — the old port-only behaviour.
+    pub containers: Vec<String>,
+}
+
+/// Watched port → the services claiming it on this node. More than one may
+/// claim the same port, each through its own replicas.
+pub type TriggerMap = HashMap<u16, Vec<TriggerOwner>>;
+
+/// The service whose trigger `container` should fire on `port`, if any.
+///
+/// The ipset that queues these packets matches on destination port alone, so a
+/// port watched for one service catches every container on the node. Resolving
+/// the owner by container is what keeps a co-located container's traffic from
+/// being attributed to — and rejected by — someone else's trigger.
+fn owner_for<'a>(map: &'a TriggerMap, container: &str, port: u16) -> Option<&'a str> {
+    let owners = map.get(&port)?;
+    owners
+        .iter()
+        .find(|o| o.containers.iter().any(|c| c == container))
+        .or_else(|| owners.iter().find(|o| o.containers.is_empty()))
+        .map(|o| o.service.as_str())
+}
+
 /// State shared by every per-packet handler. Cloned freely across tokio tasks.
 #[derive(Clone)]
 pub struct ListenerCtx {
     pub grpc: NullnetGrpcInterface,
     pub cache: BridgeIpCache,
-    pub port_to_service: Arc<RwLock<HashMap<u16, String>>>,
+    pub trigger_owners: Arc<RwLock<TriggerMap>>,
     pub triggers_state: Arc<TriggersState>,
     pub semaphore: Arc<Semaphore>,
 }
@@ -85,10 +115,13 @@ async fn handle_packet(mut msg: Message, ctx: ListenerCtx, verdict_tx: Sender<Me
         return;
     };
 
-    let service = ctx.port_to_service.read().unwrap().get(&dst_port).cloned();
+    let service = owner_for(&ctx.trigger_owners.read().unwrap(), &container, dst_port)
+        .map(ToString::to_string);
     let Some(service) = service else {
-        // Port left the watched set between rule check and recv — rare but
-        // possible during config updates. Pass through.
+        // Either the port is watched for some other service's containers — this
+        // container just happens to talk to it, and attributing the packet would
+        // get it rejected server-side and dropped — or the port left the set
+        // between the rule check and recv. Pass through either way.
         msg.set_verdict(Verdict::Accept);
         let _ = verdict_tx.send(msg);
         return;
@@ -228,4 +261,80 @@ fn report_trigger_send_failed(
     tokio::spawn(async move {
         let _ = grpc.report_event(event).await;
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TriggerMap, TriggerOwner, owner_for};
+
+    fn owner(service: &str, containers: &[&str]) -> TriggerOwner {
+        TriggerOwner {
+            service: service.to_string(),
+            containers: containers.iter().map(|c| (*c).to_string()).collect(),
+        }
+    }
+
+    /// The instaprotek case: `service` triggers on 8932, which is also
+    /// `api-prod-v2`'s backend port. Every co-located container talks to that
+    /// port, and before scoping each one was attributed to `service` — the
+    /// server then found no matching replica and the client dropped the SYN.
+    #[test]
+    fn foreign_container_on_a_watched_port_is_not_attributed() {
+        let map: TriggerMap = TriggerMap::from([(8932, vec![owner("service", &["svc_c1"])])]);
+
+        assert_eq!(owner_for(&map, "svc_c1", 8932), Some("service"));
+        assert_eq!(
+            owner_for(&map, "portal_c1", 8932),
+            None,
+            "a container that doesn't host the declaring service must pass through"
+        );
+    }
+
+    #[test]
+    fn unwatched_port_is_a_miss() {
+        let map: TriggerMap = TriggerMap::from([(8932, vec![owner("service", &["svc_c1"])])]);
+        assert_eq!(owner_for(&map, "svc_c1", 9999), None);
+    }
+
+    /// Several replicas of one service on the same node all own its trigger.
+    #[test]
+    fn every_replica_of_the_declaring_service_owns_it() {
+        let map: TriggerMap =
+            TriggerMap::from([(8932, vec![owner("service", &["svc_c1", "svc_c2"])])]);
+        assert_eq!(owner_for(&map, "svc_c1", 8932), Some("service"));
+        assert_eq!(owner_for(&map, "svc_c2", 8932), Some("service"));
+    }
+
+    /// Two services may now claim the same port on one node; each resolves to
+    /// its own, which was impossible while the map was keyed by port alone.
+    #[test]
+    fn two_services_can_share_a_port() {
+        let map: TriggerMap = TriggerMap::from([(
+            8932,
+            vec![owner("service", &["svc_c1"]), owner("other", &["other_c1"])],
+        )]);
+        assert_eq!(owner_for(&map, "svc_c1", 8932), Some("service"));
+        assert_eq!(owner_for(&map, "other_c1", 8932), Some("other"));
+        assert_eq!(owner_for(&map, "stranger_c1", 8932), None);
+    }
+
+    /// A server predating `ServiceTrigger.containers` sends none, and must keep
+    /// behaving exactly as before: any container matches.
+    #[test]
+    fn container_less_owner_matches_anything() {
+        let map: TriggerMap = TriggerMap::from([(8932, vec![owner("service", &[])])]);
+        assert_eq!(owner_for(&map, "anything", 8932), Some("service"));
+    }
+
+    /// Mixed fleet: a scoped owner must win over a legacy catch-all for its own
+    /// container, and the catch-all still covers everyone else.
+    #[test]
+    fn scoped_owner_wins_over_legacy_catch_all() {
+        let map: TriggerMap = TriggerMap::from([(
+            8932,
+            vec![owner("legacy", &[]), owner("scoped", &["scoped_c1"])],
+        )]);
+        assert_eq!(owner_for(&map, "scoped_c1", 8932), Some("scoped"));
+        assert_eq!(owner_for(&map, "someone_else", 8932), Some("legacy"));
+    }
 }

--- a/members/nullnet-client/src/nfqueue/mod.rs
+++ b/members/nullnet-client/src/nfqueue/mod.rs
@@ -5,6 +5,7 @@ mod parse;
 mod recv_loop;
 
 pub use cache::BridgeIpCache;
+pub use listener::{TriggerMap, TriggerOwner};
 
 use crate::commands::nfqueue as rules;
 use crate::egress_policy::PolicyVerdicts;
@@ -34,12 +35,12 @@ use tokio::sync::mpsc::UnboundedReceiver;
 pub fn spawn_listener(
     grpc: NullnetGrpcInterface,
     triggers_state: Arc<TriggersState>,
-    config_rx: UnboundedReceiver<HashMap<u16, String>>,
+    config_rx: UnboundedReceiver<TriggerMap>,
     docker_changed: Arc<Notify>,
     cache: BridgeIpCache,
     verdicts: Arc<PolicyVerdicts>,
 ) {
-    let port_to_service: Arc<RwLock<HashMap<u16, String>>> = Arc::new(RwLock::new(HashMap::new()));
+    let trigger_owners: Arc<RwLock<TriggerMap>> = Arc::new(RwLock::new(HashMap::new()));
 
     // Initial cache populate + long-running docker-events watcher. The
     // watcher pings `docker_changed` after every refresh so the
@@ -54,14 +55,14 @@ pub fn spawn_listener(
         });
     }
 
-    // Config consumer: each services-list refresh produces a port→service
-    // map. We diff vs the previous, push the diff to the ipset (so the
-    // kernel knows which ports to queue), then atomically replace our
-    // userspace port→service lookup that the handler reads.
+    // Config consumer: each services-list refresh produces a port → owners
+    // map. We diff the ports vs the previous set, push the diff to the ipset
+    // (so the kernel knows which ports to queue), then atomically replace the
+    // userspace lookup the handler reads to resolve a packet's owner.
     {
-        let port_to_service = port_to_service.clone();
+        let trigger_owners = trigger_owners.clone();
         tokio::spawn(async move {
-            consume_config(config_rx, port_to_service).await;
+            consume_config(config_rx, trigger_owners).await;
         });
     }
 
@@ -77,7 +78,7 @@ pub fn spawn_listener(
     let ctx = ListenerCtx {
         grpc,
         cache,
-        port_to_service,
+        trigger_owners,
         triggers_state,
         semaphore: Arc::new(Semaphore::new(HANDLER_CONCURRENCY)),
     };
@@ -85,8 +86,8 @@ pub fn spawn_listener(
 }
 
 async fn consume_config(
-    mut config_rx: UnboundedReceiver<HashMap<u16, String>>,
-    port_to_service: Arc<RwLock<HashMap<u16, String>>>,
+    mut config_rx: UnboundedReceiver<TriggerMap>,
+    trigger_owners: Arc<RwLock<TriggerMap>>,
 ) {
     let mut current_ports: HashSet<u16> = HashSet::new();
     while let Some(new_map) = config_rx.recv().await {
@@ -94,7 +95,7 @@ async fn consume_config(
         rules::apply_ports_diff(&current_ports, &new_ports);
         // Swap the lookup. Sync RwLock; write is brief, never held across
         // an `.await`.
-        *port_to_service.write().unwrap() = new_map;
+        *trigger_owners.write().unwrap() = new_map;
         current_ports = new_ports;
     }
 }

--- a/members/nullnet-grpc-lib/proto/nullnet_grpc.proto
+++ b/members/nullnet-grpc-lib/proto/nullnet_grpc.proto
@@ -231,6 +231,11 @@ message ServicesListResponse {
 message ServiceTrigger {
   string service_name = 1;
   repeated uint32 ports = 2;
+  // Real container names hosting this service on the receiving node — the same
+  // string space as the client's bridge-IP cache and as Container.real_name.
+  // Scopes the trigger to its own replicas; empty means a server that predates
+  // this field, and the client then falls back to matching any container.
+  repeated string containers = 3;
 }
 
 message HostMapping {

--- a/members/nullnet-grpc-lib/src/proto/nullnet_grpc.rs
+++ b/members/nullnet-grpc-lib/src/proto/nullnet_grpc.rs
@@ -223,6 +223,12 @@ pub struct ServiceTrigger {
     pub service_name: ::prost::alloc::string::String,
     #[prost(uint32, repeated, tag = "2")]
     pub ports: ::prost::alloc::vec::Vec<u32>,
+    /// Real container names hosting this service on the receiving node — the same
+    /// string space as the client's bridge-IP cache and as Container.real_name.
+    /// Scopes the trigger to its own replicas; empty means a server that predates
+    /// this field, and the client then falls back to matching any container.
+    #[prost(string, repeated, tag = "3")]
+    pub containers: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct HostMapping {

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -84,6 +84,61 @@ fn build_port_mapping_bundle(stacks: &StackMap) -> PortMappingBundle {
     PortMappingBundle { mappings }
 }
 
+/// Build the trigger config for one node: the triggers of the services it
+/// declared as hosting, each carrying the real container names hosting that
+/// service *there*.
+///
+/// The client's NFQUEUE watch is a destination-port match, so a watched port
+/// catches every container on the node. The container list is what lets it tell
+/// the declaring service's own traffic from a co-located container that merely
+/// talks to the same port — the latter used to be attributed to the declaring
+/// service, rejected by `handle_backend_trigger`, and dropped.
+///
+/// A service the node hosts as a bare process contributes no containers and is
+/// skipped: its trigger can never fire (the NFQUEUE path passes host traffic
+/// straight through), and shipping it would claim the port with an owner that
+/// matches every container instead of none.
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_service_triggers(
+    services: &StackMap,
+    declared: &HashMap<String, Vec<(String, u16, Option<String>)>>,
+) -> Vec<ServiceTrigger> {
+    let mut containers_by_service: HashMap<(&str, &str), Vec<&str>> = HashMap::new();
+    for (stack, list) in declared {
+        for (name, _, docker) in list {
+            let entry = containers_by_service
+                .entry((stack.as_str(), name.as_str()))
+                .or_default();
+            if let Some(container) = docker.as_deref()
+                && !entry.contains(&container)
+            {
+                entry.push(container);
+            }
+        }
+    }
+
+    let mut service_triggers: Vec<ServiceTrigger> = containers_by_service
+        .into_iter()
+        .filter(|(_, containers)| !containers.is_empty())
+        .filter_map(|((stack, name), mut containers)| {
+            let triggers = services.get(stack)?.get(name).map(ServiceInfo::triggers)?;
+            if triggers.is_empty() {
+                return None;
+            }
+            let mut ports: Vec<u32> = triggers.keys().map(|p| u32::from(*p)).collect();
+            ports.sort_unstable();
+            containers.sort_unstable();
+            Some(ServiceTrigger {
+                service_name: name.to_string(),
+                ports,
+                containers: containers.into_iter().map(ToString::to_string).collect(),
+            })
+        })
+        .collect();
+    service_triggers.sort_by(|a, b| a.service_name.cmp(&b.service_name));
+    service_triggers
+}
+
 /// Return the stack name that holds `service_name`, if any. Service names
 /// are unique within a stack but may collide across stacks; this returns
 /// the first match in iteration order.
@@ -511,34 +566,8 @@ impl NullnetGrpcImpl {
             .teardown_egress_edges_for_missing_containers(sender_ip, &live_containers)
             .await;
 
-        // Build the trigger config to send back: only the triggers attached
-        // to the services this caller declared as hosting. Look up triggers
-        // in the same stack the entry was declared under.
         let guard = self.services.read().await;
-        let mut seen: HashSet<(String, String)> = HashSet::new();
-        let mut service_triggers: Vec<ServiceTrigger> = Vec::new();
-        for (stack, list) in &service_list_by_stack {
-            let Some(stack_map) = guard.get(stack) else {
-                continue;
-            };
-            for (name, _, _) in list {
-                if !seen.insert((stack.clone(), name.clone())) {
-                    continue;
-                }
-                let Some(triggers) = stack_map.get(name).map(ServiceInfo::triggers) else {
-                    continue;
-                };
-                if triggers.is_empty() {
-                    continue;
-                }
-                let mut ports: Vec<u32> = triggers.keys().map(|p| u32::from(*p)).collect();
-                ports.sort_unstable();
-                service_triggers.push(ServiceTrigger {
-                    service_name: name.clone(),
-                    ports,
-                });
-            }
-        }
+        let service_triggers = build_service_triggers(&guard, &service_list_by_stack);
 
         Ok(Response::new(ServicesListResponse { service_triggers }))
     }

--- a/members/nullnet-server/src/tests.rs
+++ b/members/nullnet-server/src/tests.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use crate::graphviz::render_graphviz;
-use crate::nullnet_grpc_impl::NullnetGrpcImpl;
+use crate::nullnet_grpc_impl::{NullnetGrpcImpl, build_service_triggers};
 use crate::services::changes::dep_chain_intact;
 use crate::services::clients::Client;
 use crate::services::input::{ServicesToml, StackMap, apply_config_update};
@@ -3148,4 +3148,87 @@ async fn concurrent_requests_same_client_tear_down_cleanly() {
         residual.len(),
         residual.join("\n")
     );
+}
+
+// ===========================================================================
+// trigger_scoping: a trigger port is watched host-wide, so the trigger config
+// has to say which containers actually own it. Without that, every co-located
+// container dialing the port is attributed to the declaring service, rejected
+// by `handle_backend_trigger`, and its SYN dropped by the client.
+// ===========================================================================
+
+const TRIGGER_SCOPING: &str = "trigger_scoping";
+
+fn declared_by_stack(
+    entries: Vec<(&str, u16, Option<&str>)>,
+) -> HashMap<String, Vec<(String, u16, Option<String>)>> {
+    HashMap::from([(
+        TEST_STACK.to_string(),
+        entries
+            .into_iter()
+            .map(|(n, p, d)| (n.to_string(), p, d.map(ToString::to_string)))
+            .collect(),
+    )])
+}
+
+#[tokio::test]
+async fn trigger_carries_the_containers_that_own_it() {
+    let services = load_fixture(TRIGGER_SCOPING).await;
+    let declared = declared_by_stack(vec![
+        ("S", 3000, Some("stack_s.1.abc")),
+        ("P", 8932, Some("stack_p.1.xyz")),
+    ]);
+
+    let triggers = build_service_triggers(&services, &declared);
+
+    assert_eq!(triggers.len(), 1, "only S declares a trigger");
+    assert_eq!(triggers[0].service_name, "S");
+    assert_eq!(triggers[0].ports, vec![8932]);
+    assert_eq!(
+        triggers[0].containers,
+        vec!["stack_s.1.abc"],
+        "P's container hosts the callee, not the trigger — it must not be listed, \
+         or P's own traffic on 8932 would be attributed to S's trigger"
+    );
+}
+
+/// Swarm: every replica of the declaring service on this node owns the trigger.
+#[tokio::test]
+async fn trigger_lists_every_colocated_replica() {
+    let services = load_fixture(TRIGGER_SCOPING).await;
+    let declared = declared_by_stack(vec![
+        ("S", 3000, Some("stack_s.2.def")),
+        ("S", 3000, Some("stack_s.1.abc")),
+        ("S", 3000, Some("stack_s.1.abc")),
+    ]);
+
+    let triggers = build_service_triggers(&services, &declared);
+
+    assert_eq!(triggers.len(), 1);
+    assert_eq!(
+        triggers[0].containers,
+        vec!["stack_s.1.abc", "stack_s.2.def"],
+        "sorted and de-duplicated"
+    );
+}
+
+/// A bare-process service's trigger can never fire — the NFQUEUE path resolves
+/// an initiator container and passes host traffic straight through. Shipping it
+/// would claim the port with an owner matching every container instead of none,
+/// which is exactly the bug being fixed.
+#[tokio::test]
+async fn bare_process_service_ships_no_trigger() {
+    let services = load_fixture(TRIGGER_SCOPING).await;
+    let declared = declared_by_stack(vec![("HostSvc", 4000, None)]);
+
+    assert!(build_service_triggers(&services, &declared).is_empty());
+}
+
+/// A node hosting neither declares nothing.
+#[tokio::test]
+async fn node_hosting_no_trigger_service_gets_nothing() {
+    let services = load_fixture(TRIGGER_SCOPING).await;
+    let declared = declared_by_stack(vec![("P", 8932, Some("stack_p.1.xyz"))]);
+
+    assert!(build_service_triggers(&services, &declared).is_empty());
 }

--- a/members/nullnet-server/tests/fixtures/trigger_scoping/services.toml
+++ b/members/nullnet-server/tests/fixtures/trigger_scoping/services.toml
@@ -1,0 +1,27 @@
+# S declares a trigger on P, and P is also the backend port of the service that
+# trigger reaches — the instaprotek shape, where `service` triggers on 8932 and
+# api-prod-v2 listens on 8932. Co-located containers legitimately dial P.
+[[services]]
+name = "S"
+docker_container = "s_match"
+port = 3000
+
+[[services.triggers]]
+port = 8932
+chain = ["P"]
+
+[[services]]
+name = "P"
+docker_container = "p_match"
+port = 8932
+timeout = 0
+
+# Hosted as a bare process, and also declares a trigger on the same port.
+[[services]]
+name = "HostSvc"
+process_path = "/usr/bin/hostsvc"
+port = 4000
+
+[[services.triggers]]
+port = 8932
+chain = ["P"]


### PR DESCRIPTION
The client's trigger map was keyed by port alone, so any container on a node
  dialing a watched port was attributed to the service that declared it. The
  server then found no matching replica, `backend_trigger` errored, and the
  client dropped the SYN — retries took the same path, so the connection never
  established.

  `ServiceTrigger` now carries the real container names hosting the service on
  the receiving node (proto field 3, additive), and the client resolves a queued
  packet's owner by container, passing through on a miss. A service the node
  hosts as a bare process ships no trigger: it could never fire, and shipping it
  claimed the port with an owner matching every container.

Fixes #125