### PR TITLE
ui: improve topology graph readability (#136)

### DIFF
--- a/members/nullnet-server/ui/src/App.tsx
+++ b/members/nullnet-server/ui/src/App.tsx
@@ -12,6 +12,7 @@ import Events from './pages/Events';
 import Certificates from './pages/Certificates';
 import Topology from './pages/Topology';
 import Users from './pages/Users';
+import DebugTopology from './pages/DebugTopology';
 
 export default function App() {
   return (
@@ -20,6 +21,9 @@ export default function App() {
         <BrowserRouter>
           <Routes>
             <Route path="/login" element={<Login />} />
+            {/* Not linked from the sidebar — dev tool, renders pasted/loaded
+                JSON with no backend involved, so it doesn't need auth. */}
+            <Route path="/debug/topology" element={<DebugTopology />} />
             <Route path="/" element={<RequireAuth><Dashboard /></RequireAuth>} />
             <Route path="/services" element={<RequireAuth><Services /></RequireAuth>} />
             <Route path="/nodes" element={<RequireAuth><Nodes /></RequireAuth>} />

--- a/members/nullnet-server/ui/src/components/topology/LayoutModeToggle.tsx
+++ b/members/nullnet-server/ui/src/components/topology/LayoutModeToggle.tsx
@@ -1,0 +1,49 @@
+import type { LayoutMode } from './types';
+
+interface Props {
+  mode: LayoutMode;
+  onChange: (mode: LayoutMode) => void;
+}
+
+const OPTIONS: { mode: LayoutMode; label: string }[] = [
+  { mode: 'layered', label: 'layered' },
+  { mode: 'matrix', label: 'matrix' },
+];
+
+// Small segmented control for switching between the available topology
+// layouts (layered default, matrix) — styled to match ZoomFrame's existing
+// "reset view" overlay button.
+export default function LayoutModeToggle({ mode, onChange }: Props) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        background: 'rgba(255,255,255,.06)',
+        border: '1px solid rgba(255,255,255,.12)',
+        borderRadius: 5,
+        overflow: 'hidden',
+      }}
+    >
+      {OPTIONS.map(opt => {
+        const active = opt.mode === mode;
+        return (
+          <button
+            key={opt.mode}
+            onClick={() => onChange(opt.mode)}
+            style={{
+              background: active ? 'rgba(91,156,246,.25)' : 'transparent',
+              border: 'none',
+              color: active ? 'rgba(255,255,255,.9)' : 'rgba(255,255,255,.5)',
+              fontSize: 10,
+              padding: '3px 7px',
+              whiteSpace: 'nowrap',
+              cursor: 'pointer',
+            }}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/TopologyContext.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyContext.tsx
@@ -1,7 +1,9 @@
 import { createContext, useContext, useEffect, useMemo, useReducer, useRef } from 'react';
 import type { ChainJson, GraphJson, ServiceJson, SessionJson } from '../../types';
-import type { PanelState } from './types';
-import { INTERNET_ID } from './types';
+import type { LayoutMode, PanelState } from './types';
+import { INTERNET_ID, LAYOUT_MODES } from './types';
+
+const LAYOUT_MODE_STORAGE_KEY = 'topology-layout-mode';
 import { useApi } from '../../hooks/useApi';
 
 // ── Data context ──────────────────────────────────────────────────────────────
@@ -25,6 +27,7 @@ const TopologyDataContext = createContext<TopologyData>({
 interface UIState {
   panel: PanelState;
   focusedClientIp: string | null;
+  layoutMode: LayoutMode;
 }
 
 export type UIAction =
@@ -33,11 +36,19 @@ export type UIAction =
   | { type: 'PANEL_CLOSED' }
   | { type: 'CLIENT_FOCUSED'; ip: string }
   | { type: 'FOCUS_CLEARED' }
-  | { type: 'STACK_CHANGED' };
+  | { type: 'STACK_CHANGED' }
+  | { type: 'LAYOUT_MODE_CHANGED'; mode: LayoutMode };
+
+function loadInitialLayoutMode(): LayoutMode {
+  if (typeof localStorage === 'undefined') return 'layered';
+  const stored = localStorage.getItem(LAYOUT_MODE_STORAGE_KEY);
+  return (LAYOUT_MODES as string[]).includes(stored ?? '') ? (stored as LayoutMode) : 'layered';
+}
 
 const initialUIState: UIState = {
   panel: null,
   focusedClientIp: null,
+  layoutMode: loadInitialLayoutMode(),
 };
 
 function uiReducer(state: UIState, action: UIAction): UIState {
@@ -78,6 +89,8 @@ function uiReducer(state: UIState, action: UIAction): UIState {
       return { ...state, focusedClientIp: null };
     case 'STACK_CHANGED':
       return { ...state, panel: null, focusedClientIp: null };
+    case 'LAYOUT_MODE_CHANGED':
+      return { ...state, layoutMode: action.mode };
   }
 }
 
@@ -121,6 +134,12 @@ export function TopologyProvider({
   const { data: chains, refetch: refetchChains } = useApi<ChainJson[]>(`/api/chains/${stack}`);
 
   const [uiState, dispatch] = useReducer(uiReducer, initialUIState);
+
+  // Persist the chosen layout mode across reloads (kept out of the reducer to
+  // keep it a pure function of state+action).
+  useEffect(() => {
+    localStorage.setItem(LAYOUT_MODE_STORAGE_KEY, uiState.layoutMode);
+  }, [uiState.layoutMode]);
 
   // Reset panel and focus when the active stack changes (not on initial mount).
   const prevStackRef = useRef(stack);

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraph.tsx
@@ -1,6 +1,8 @@
 import { useTopologyData, useTopologyUI } from './TopologyContext';
 import TopologyGraphSvg from './TopologyGraphSvg';
+import TopologyMatrix from './TopologyMatrix';
 import ZoomFrame from './ZoomFrame';
+import LayoutModeToggle from './LayoutModeToggle';
 
 interface Props {
   height?: number | string;
@@ -12,6 +14,7 @@ interface Props {
 export default function TopologyGraph({ height = 520, fill, anchor, grow }: Props) {
   const { graph } = useTopologyData();
   const {
+    layoutMode,
     selectedNodeId,
     selectedEdgeKey,
     focusedNetIds,
@@ -23,20 +26,44 @@ export default function TopologyGraph({ height = 520, fill, anchor, grow }: Prop
   if (!graph) return null;
 
   return (
-    <ZoomFrame height={height} fill={fill} anchor={anchor} grow={grow}>
-      <TopologyGraphSvg
-        graph={graph}
-        selectedNodeId={selectedNodeId}
-        selectedEdgeKey={selectedEdgeKey}
-        focusedNetIds={focusedNetIds}
-        focusedSessions={focusedSessions}
-        nodeIps={nodeIps}
-        onNodeClick={id => dispatch({ type: 'NODE_CLICKED', nodeId: id })}
-        onEdgeClick={(fromId, toId, edgeIndices) =>
-          dispatch({ type: 'EDGE_CLICKED', fromId, toId, edgeIndices })
-        }
-        onBgClick={() => dispatch({ type: 'PANEL_CLOSED' })}
-      />
+    <ZoomFrame
+      height={height}
+      fill={fill}
+      anchor={anchor}
+      grow={grow}
+      overlay={
+        <LayoutModeToggle
+          mode={layoutMode}
+          onChange={mode => dispatch({ type: 'LAYOUT_MODE_CHANGED', mode })}
+        />
+      }
+    >
+      {layoutMode === 'matrix' ? (
+        <TopologyMatrix
+          graph={graph}
+          selectedNodeId={selectedNodeId}
+          selectedEdgeKey={selectedEdgeKey}
+          onNodeClick={id => dispatch({ type: 'NODE_CLICKED', nodeId: id })}
+          onEdgeClick={(fromId, toId, edgeIndices) =>
+            dispatch({ type: 'EDGE_CLICKED', fromId, toId, edgeIndices })
+          }
+          onBgClick={() => dispatch({ type: 'PANEL_CLOSED' })}
+        />
+      ) : (
+        <TopologyGraphSvg
+          graph={graph}
+          selectedNodeId={selectedNodeId}
+          selectedEdgeKey={selectedEdgeKey}
+          focusedNetIds={focusedNetIds}
+          focusedSessions={focusedSessions}
+          nodeIps={nodeIps}
+          onNodeClick={id => dispatch({ type: 'NODE_CLICKED', nodeId: id })}
+          onEdgeClick={(fromId, toId, edgeIndices) =>
+            dispatch({ type: 'EDGE_CLICKED', fromId, toId, edgeIndices })
+          }
+          onBgClick={() => dispatch({ type: 'PANEL_CLOSED' })}
+        />
+      )}
     </ZoomFrame>
   );
 }

--- a/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyGraphSvg.tsx
@@ -1,7 +1,30 @@
 import { useEffect, useRef } from 'react';
 import type { GraphJson, SessionJson } from '../../types';
 import { NODE_W, NODE_H, INET_W, INET_H, INTERNET_ID } from './types';
-import { buildTopoGraph, layoutNodes, svgDims, edgePath, egressEdgePath, inetEdgePath, edgeLabelPoints } from './layout';
+import type { TopoNode } from './types';
+import {
+  buildTopoGraph, layoutNodes, svgDims,
+  edgePath, edgeMidpoint, egressEdgePath, egressLabelPoint, inetEdgePath, longEdgePath, edgeLabelPoints,
+} from './layout';
+
+// A modest bow is enough to visually separate two curves, but their labels
+// are much wider than the stroke — they need far more room to actually clear
+// each other, so the two use different magnitudes of the same offset.
+const MUTUAL_PATH_OFFSET = 10;
+const MUTUAL_LABEL_OFFSET = 55;
+
+// Small dark pill behind a default edge label so two labels landing at
+// nearby positions in a dense graph (e.g. an egress label and an unrelated
+// edge's session count) stay legible instead of blending into each other.
+function EdgeLabel({ x, y, text, color }: { x: number; y: number; text: string; color: string }) {
+  const w = text.length * 5.2 + 10;
+  return (
+    <g pointerEvents="none">
+      <rect x={x - w / 2} y={y - 9} width={w} height={12} rx="3" fill="rgba(3,5,8,.78)" />
+      <text x={x} y={y} textAnchor="middle" fill={color} fontSize="9">{text}</text>
+    </g>
+  );
+}
 
 interface Props {
   graph: GraphJson;
@@ -27,8 +50,9 @@ export default function TopologyGraphSvg({
   onBgClick,
 }: Props) {
   const { nodes, edges } = buildTopoGraph(graph);
+  const nodeById = new Map(nodes.map(n => [n.id, n]));
 
-  const pos = layoutNodes(nodes, edges);
+  const { pos, waypoints } = layoutNodes(nodes, edges);
   const { w, h } = svgDims(pos, nodes);
 
   // Track edge keys already seen so a connect animation plays only once per
@@ -60,8 +84,26 @@ export default function TopologyGraphSvg({
     focusedNodeIds.add(INTERNET_ID);
   }
 
+  // Selecting a node highlights just its direct connections — independent
+  // of, and composable with, the client-session focus above (the two are
+  // effectively mutually exclusive in practice, so a plain OR of the two
+  // "should this be dimmed" conditions below is sufficient).
+  const highlightSource = selectedNodeId;
+  const highlightEdgeKeys = new Set<string>();
+  const highlightNodeIds = new Set<string>();
+  if (highlightSource) {
+    for (const e of edges) {
+      if (e.from === highlightSource || e.to === highlightSource) {
+        highlightEdgeKeys.add(`${e.from}\0${e.to}`);
+        highlightNodeIds.add(e.from);
+        highlightNodeIds.add(e.to);
+      }
+    }
+    highlightNodeIds.add(highlightSource);
+  }
+
   function getNodeIp(id: string): string | null {
-    const node = nodes.find(n => n.id === id);
+    const node = nodeById.get(id);
     if (!node) return null;
     if (node.kind === 'proxy') return node.id;
     if (node.kind === 'service') return nodeIps.get(id) ?? null;
@@ -69,6 +111,110 @@ export default function TopologyGraphSvg({
   }
 
   const interactive = !!(onNodeClick || onEdgeClick);
+
+  // Shared node visuals: internet pill / proxy dashed box / service card.
+  function renderNode(n: TopoNode, key: string) {
+    const p = pos.get(n.id);
+    if (!p) return null;
+    const isSel = n.id === selectedNodeId;
+    const nodeDimmed = (focusedNetIds != null && !focusedNodeIds.has(n.id)) ||
+      (highlightSource != null && !highlightNodeIds.has(n.id));
+    const clickHandler = onNodeClick ? (ev: { stopPropagation(): void }) => { ev.stopPropagation(); onNodeClick(n.id); } : undefined;
+    const clipId = `nc-${key}`;
+
+    if (n.kind === 'internet') {
+      return (
+        <g key={INTERNET_ID} onClick={clickHandler} style={{ cursor: onNodeClick ? 'pointer' : 'default', opacity: nodeDimmed ? 0.12 : 1 }}>
+          {isSel && (
+            <rect x={p.x - 3} y={p.y - 3} width={INET_W + 6} height={INET_H + 6} rx="14"
+              fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
+          )}
+          <rect x={p.x} y={p.y} width={INET_W} height={INET_H} rx="11"
+            fill="rgba(91,156,246,.05)" stroke="rgba(91,156,246,.2)"
+            strokeWidth="1" strokeDasharray="4 3" filter="url(#gT)" />
+          <text x={p.x + INET_W / 2} y={p.y + INET_H / 2 + 4}
+            textAnchor="middle" fill="rgba(91,156,246,.7)" fontSize="9.5" fontWeight="600" pointerEvents="none">
+            ⬡ internet
+          </text>
+        </g>
+      );
+    }
+
+    if (n.kind === 'proxy') {
+      if (n.placeholder) {
+        return (
+          <g key={n.id} style={{ opacity: nodeDimmed ? 0.12 : 1 }}>
+            <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
+              fill="rgba(255,255,255,.02)" stroke="rgba(255,255,255,.12)"
+              strokeWidth="1" strokeDasharray="5 3" />
+            <circle cx={p.x + 15} cy={p.y + 22} r="3.5" fill="none" stroke="rgba(255,255,255,.25)" strokeWidth="1.5" />
+            <g clipPath={`url(#${clipId})`} pointerEvents="none">
+              <defs>
+                <clipPath id={clipId}>
+                  <rect x={p.x + 4} y={p.y + 2} width={NODE_W - 8} height={NODE_H - 4} />
+                </clipPath>
+              </defs>
+              <text x={p.x + 27} y={p.y + 20} fill="rgba(255,255,255,.35)" fontSize="9.5" fontWeight="500">proxy</text>
+              <text x={p.x + 27} y={p.y + 32} fill="rgba(255,255,255,.25)" fontSize="7.5">no active connections</text>
+            </g>
+          </g>
+        );
+      }
+      return (
+        <g key={n.id} onClick={clickHandler} style={{ cursor: onNodeClick ? 'pointer' : 'default', opacity: nodeDimmed ? 0.12 : 1 }}>
+          <defs>
+            <clipPath id={clipId}>
+              <rect x={p.x + 4} y={p.y + 2} width={NODE_W - 8} height={NODE_H - 4} />
+            </clipPath>
+          </defs>
+          {isSel && (
+            <rect x={p.x - 3} y={p.y - 3} width={NODE_W + 6} height={NODE_H + 6} rx="10"
+              fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
+          )}
+          <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
+            fill="rgba(251,191,36,.06)" stroke="rgba(251,191,36,.4)"
+            strokeWidth="1" strokeDasharray="5 3" filter="url(#gT)" />
+          <circle cx={p.x + 15} cy={p.y + 22} r="3.5" fill="#fbbf24" />
+          <g clipPath={`url(#${clipId})`} pointerEvents="none">
+            <text x={p.x + 27} y={p.y + 20} fill="rgba(251,191,36,.9)" fontSize="9.5" fontWeight="500">proxy</text>
+            <text x={p.x + 27} y={p.y + 32} fill="rgba(255,255,255,.4)" fontSize="8" fontFamily="'JetBrains Mono',monospace">{n.id}</text>
+          </g>
+        </g>
+      );
+    }
+
+    const color = n.registered ? '#34d399' : '#f87171';
+    const strokeColor = n.registered ? 'rgba(52,211,153,.3)' : 'rgba(248,113,113,.2)';
+    const ip = nodeIps.get(n.id);
+    return (
+      <g key={n.id} onClick={clickHandler} style={{ cursor: onNodeClick ? 'pointer' : 'default', opacity: nodeDimmed ? 0.12 : 1 }}>
+        <title>{n.id}</title>
+        <defs>
+          <clipPath id={clipId}>
+            <rect x={p.x + 4} y={p.y + 2} width={NODE_W - 8} height={NODE_H - 4} />
+          </clipPath>
+        </defs>
+        {isSel && (
+          <rect x={p.x - 3} y={p.y - 3} width={NODE_W + 6} height={NODE_H + 6} rx="10"
+            fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
+        )}
+        <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
+          fill="rgba(255,255,255,.04)" stroke={strokeColor} strokeWidth="1" filter="url(#gT)" />
+        <circle cx={p.x + 15} cy={p.y + 17} r="3.5" fill={color} />
+        <g clipPath={`url(#${clipId})`} pointerEvents="none">
+          <text x={p.x + 27} y={p.y + 20} fill="rgba(255,255,255,.85)" fontSize="9.5" fontWeight="500">{n.id}</text>
+          {ip && (
+            <text x={p.x + 27} y={p.y + 31} fill="rgba(255,255,255,.35)" fontSize="8" fontFamily="'JetBrains Mono',monospace">{ip}</text>
+          )}
+          <text x={p.x + 27} y={p.y + (ip ? 42 : 31)} fill="rgba(255,255,255,.3)" fontSize="7.5">
+            {n.registered ? `${n.active_replica_count}/${n.replica_count} active` : 'unregistered'}
+            {n.registered && n.paused_replica_count > 0 ? ` · ${n.paused_replica_count} paused` : ''}
+            {n.entry_point ? ' · entry' : ''}
+          </text>
+        </g>
+      </g>
+    );
+  }
 
   return (
     <svg
@@ -98,263 +244,180 @@ export default function TopologyGraphSvg({
       {onBgClick && <rect x={0} y={0} width={w} height={h} fill="transparent" onClick={onBgClick} />}
 
       {/* Internet → Proxy edges */}
-      {/* eslint-disable-next-line react-hooks/refs -- see isNewEdge comment above */}
-      {edges.filter(e => e.isInternetEdge).map(e => {
-        const fp = pos.get(e.from);
-        const tp = pos.get(e.to);
-        if (!fp || !tp) return null;
-        const dimmed = focusedNetIds != null && !focusedNodeIds.has(e.to);
-        const edgeKey = `${e.from}\0${e.to}`;
-        const isNew = isNewEdge(edgeKey);
-        return (
-          <path
-            key={edgeKey}
-            d={inetEdgePath(fp, tp)}
-            fill="none"
-            stroke="rgba(91,156,246,.3)"
-            strokeWidth="1.5"
-            strokeDasharray="4 3"
-            markerEnd="url(#arr-inet)"
-            pointerEvents="none"
-            opacity={dimmed ? 0.1 : 1}
-            style={isNew ? { animation: 'edge-fade-in .9s ease-out' } : undefined}
-          />
-        );
-      })}
+          {/* eslint-disable-next-line react-hooks/refs -- see isNewEdge comment above */}
+          {edges.filter(e => e.isInternetEdge).map(e => {
+            const fp = pos.get(e.from);
+            const tp = pos.get(e.to);
+            if (!fp || !tp) return null;
+            const dimmed = (focusedNetIds != null && !focusedNodeIds.has(e.to)) ||
+              (highlightSource != null && !highlightNodeIds.has(e.to));
+            const edgeKey = `${e.from}\0${e.to}`;
+            const isNew = isNewEdge(edgeKey);
+            return (
+              <path
+                key={edgeKey}
+                d={inetEdgePath(fp, tp)}
+                fill="none"
+                stroke="rgba(91,156,246,.3)"
+                strokeWidth="1.5"
+                strokeDasharray="4 3"
+                markerEnd="url(#arr-inet)"
+                pointerEvents="none"
+                opacity={dimmed ? 0.1 : 1}
+                style={isNew ? { animation: 'edge-fade-in .9s ease-out' } : undefined}
+              />
+            );
+          })}
 
-      {/* Service / proxy edges */}
-      {/* eslint-disable-next-line react-hooks/refs -- see isNewEdge comment above */}
-      {edges.filter(e => !e.isInternetEdge).map(e => {
-        const fp = pos.get(e.from);
-        const tp = pos.get(e.to);
-        if (!fp || !tp) return null;
-        const edgeKey = `${e.from}\0${e.to}`;
-        const isSel = selectedEdgeKey === edgeKey;
-        const isNew = isNewEdge(edgeKey);
-        const dimmed = focusedNetIds != null && !focusedEdgeKeys.has(edgeKey);
-        const count = e.originalIndices.length;
-        const stroke = isSel
-          ? 'rgba(91,156,246,.9)'
-          : e.isEgress ? 'rgba(167,139,250,.55)'
-          : e.isProxyHop ? 'rgba(251,191,36,.35)' : 'rgba(255,255,255,.18)';
-        const arrowId = isSel ? 'arr-sel' : e.isEgress ? 'arr-egress' : e.isProxyHop ? 'arr-proxy' : 'arr';
-        const dash = isSel ? undefined : e.isEgress ? '2 4' : e.isProxyHop ? '4 3' : undefined;
-        const path = e.isEgress ? egressEdgePath(fp, tp) : edgePath(fp, tp);
-        const midX = (fp.x + tp.x) / 2 + NODE_W / 2;
-        const midY = (fp.y + tp.y) / 2 + NODE_H / 2;
+          {/* Service / proxy edges */}
+          {/* eslint-disable-next-line react-hooks/refs -- see isNewEdge comment above */}
+          {edges.filter(e => !e.isInternetEdge).map(e => {
+            const fp = pos.get(e.from);
+            const tp = pos.get(e.to);
+            if (!fp || !tp) return null;
+            const edgeKey = `${e.from}\0${e.to}`;
+            const isSel = selectedEdgeKey === edgeKey;
+            const isNew = isNewEdge(edgeKey);
+            const dimmed = (focusedNetIds != null && !focusedEdgeKeys.has(edgeKey)) ||
+              (highlightSource != null && !highlightEdgeKeys.has(edgeKey));
+            const count = e.originalIndices.length;
+            const stroke = isSel
+              ? 'rgba(91,156,246,.9)'
+              : e.isEgress ? 'rgba(167,139,250,.55)'
+              : e.isProxyHop ? 'rgba(251,191,36,.35)' : 'rgba(255,255,255,.18)';
+            const arrowId = isSel ? 'arr-sel' : e.isEgress ? 'arr-egress' : e.isProxyHop ? 'arr-proxy' : 'arr';
+            const dash = isSel ? undefined : e.isEgress ? '2 4' : e.isProxyHop ? '4 3' : undefined;
+            const wp = waypoints.get(edgeKey);
+            // A mutual pair (both A→B and B→A present, e.g. a two-node cycle)
+            // has a midpoint-symmetric geometry — without an offset, both
+            // directions draw the exact same curve and label position.
+            const isMutual = !e.isEgress && currentEdgeKeys.has(`${e.to}\0${e.from}`);
+            const mutualSign = isMutual ? (e.from < e.to ? -1 : 1) : 0;
+            // A layer-skipping egress edge gets the same reserved waypoint
+            // lane as any other long edge, so it no longer has to bow across
+            // whatever sits between the service and the (usually distant)
+            // proxy row. Adjacent-layer egress edges (no waypoints) keep the
+            // original right-bow routing, which is short enough to be fine.
+            const path = wp?.length ? longEdgePath(fp, wp, tp)
+              : e.isEgress ? egressEdgePath(fp, tp)
+              : edgePath(fp, tp, mutualSign * MUTUAL_PATH_OFFSET);
+            // edgeMidpoint assumes a direct fp-to-tp curve — on a waypoint-
+            // routed edge the actual path bends through a reserved slot that
+            // can be nowhere near that raw midpoint (and, being just the
+            // endpoints' midpoint, has no idea a real node might already sit
+            // there). Anchor the label to the middle waypoint instead, which
+            // is guaranteed collision-free by construction.
+            const { x: midX, y: midY } = wp?.length
+              ? { x: wp[Math.floor(wp.length / 2)].x + NODE_W / 2, y: wp[Math.floor(wp.length / 2)].y + NODE_H / 2 }
+              : edgeMidpoint(fp, tp, mutualSign * MUTUAL_LABEL_OFFSET);
 
-        const isFocusedEdge = focusedNetIds != null && focusedEdgeKeys.has(edgeKey);
-        const session: SessionJson | null = isFocusedEdge
-          ? (focusedSessions?.find(s => e.originalIndices.some(idx => graph.edges[idx]?.net_id === s.network_id)) ?? null)
-          : null;
-        // For chain hops the session is null (chain sessions don't carry the client IP),
-        // but we can still display the VNI by pulling it directly from the graph edge.
-        const focusedNetId: number | null = isFocusedEdge
-          ? (session?.network_id ??
-             e.originalIndices.map(idx => graph.edges[idx]?.net_id).find(id => id !== undefined && focusedNetIds!.has(id)) ??
-             null)
-          : null;
-        const lp = isFocusedEdge ? edgeLabelPoints(fp, tp) : null;
-        const srcIp = isFocusedEdge ? getNodeIp(e.from) : null;
-        const dstIp = isFocusedEdge ? getNodeIp(e.to) : null;
+            const isFocusedEdge = focusedNetIds != null && focusedEdgeKeys.has(edgeKey);
+            const session: SessionJson | null = isFocusedEdge
+              ? (focusedSessions?.find(s => e.originalIndices.some(idx => graph.edges[idx]?.net_id === s.network_id)) ?? null)
+              : null;
+            // For chain hops the session is null (chain sessions don't carry the client IP),
+            // but we can still display the VNI by pulling it directly from the graph edge.
+            const focusedNetId: number | null = isFocusedEdge
+              ? (session?.network_id ??
+                 e.originalIndices.map(idx => graph.edges[idx]?.net_id).find(id => id !== undefined && focusedNetIds!.has(id)) ??
+                 null)
+              : null;
+            const lp = isFocusedEdge ? edgeLabelPoints(fp, tp) : null;
+            const srcIp = isFocusedEdge ? getNodeIp(e.from) : null;
+            const dstIp = isFocusedEdge ? getNodeIp(e.to) : null;
 
-        return (
-          <g
-            key={edgeKey}
-            onClick={onEdgeClick ? (ev) => { ev.stopPropagation(); onEdgeClick(e.from, e.to, e.originalIndices); } : undefined}
-            style={{ cursor: onEdgeClick ? 'pointer' : 'default', opacity: dimmed ? 0.1 : 1 }}
-          >
-            {onEdgeClick && <path d={path} fill="none" stroke="transparent" strokeWidth="14" />}
-            <path
-              // pathLength normalizes stroke-dasharray/dashoffset to a 0–1 range for the
-              // draw-in animation below — only safe when the edge has no dash pattern of
-              // its own (dash === undefined); setting it on a dashed edge (proxy-hop "4 3",
-              // egress "2 4") would rescale that pattern relative to the whole path and
-              // stretch it into what looks like a solid line once the animation ends.
-              pathLength={dash === undefined ? '1' : undefined}
-              d={path} fill="none" stroke={stroke}
-              strokeWidth={isSel ? 2 : 1.5}
-              strokeDasharray={dash}
-              markerEnd={`url(#${arrowId})`}
-              pointerEvents="none"
-              style={isNew
-                ? { animation: dash === undefined ? 'edge-draw-in .9s ease-out' : 'edge-fade-in .9s ease-out' }
-                : undefined}
-            />
+            return (
+              <g
+                key={edgeKey}
+                onClick={onEdgeClick ? (ev) => { ev.stopPropagation(); onEdgeClick(e.from, e.to, e.originalIndices); } : undefined}
+                style={{ cursor: onEdgeClick ? 'pointer' : 'default', opacity: dimmed ? 0.1 : 1 }}
+              >
+                {onEdgeClick && <path d={path} fill="none" stroke="transparent" strokeWidth="14" />}
+                <path
+                  // pathLength normalizes stroke-dasharray/dashoffset to a 0–1 range for the
+                  // draw-in animation below — only safe when the edge has no dash pattern of
+                  // its own (dash === undefined); setting it on a dashed edge (proxy-hop "4 3",
+                  // egress "2 4") would rescale that pattern relative to the whole path and
+                  // stretch it into what looks like a solid line once the animation ends.
+                  pathLength={dash === undefined ? '1' : undefined}
+                  d={path} fill="none" stroke={stroke}
+                  strokeWidth={isSel ? 2 : 1.5}
+                  strokeDasharray={dash}
+                  markerEnd={`url(#${arrowId})`}
+                  pointerEvents="none"
+                  style={isNew
+                    ? { animation: dash === undefined ? 'edge-draw-in .9s ease-out' : 'edge-fade-in .9s ease-out' }
+                    : undefined}
+                />
 
-            {/* Egress edge marker label (bows out to the right of both nodes) */}
-            {interactive && e.isEgress && !isSel && (
-              <text x={Math.max(fp.x, tp.x) + NODE_W + 30} y={(fp.y + tp.y) / 2 + NODE_H / 2}
-                textAnchor="middle" fill="rgba(167,139,250,.7)" fontSize="8" pointerEvents="none">
-                egress
-              </text>
-            )}
+                {/* Egress edge marker label — anchored to the curve's own bow
+                    peak, or its waypoint-lane midpoint when it has one */}
+                {interactive && e.isEgress && !isSel && (() => {
+                  const lp = wp?.length ? edgeMidpoint(fp, tp) : egressLabelPoint(fp, tp);
+                  return <EdgeLabel x={lp.x} y={lp.y} text="egress" color="rgba(167,139,250,.8)" />;
+                })()}
 
-            {/* Default labels — hidden when client is focused or on egress edges */}
-            {interactive && !isSel && !isFocusedEdge && !e.isEgress && count > 1 && (
-              <text x={midX} y={midY} textAnchor="middle" fill="rgba(255,255,255,.45)" fontSize="9" pointerEvents="none">
-                {count} sessions
-              </text>
-            )}
-            {interactive && !isSel && !isFocusedEdge && !e.isEgress && count === 1 && e.setup_ms > 0 && (
-              <text x={midX} y={midY} textAnchor="middle" fill="rgba(255,255,255,.3)" fontSize="9" pointerEvents="none">
-                net {e.net_id} · {e.setup_ms}ms
-              </text>
-            )}
-
-            {/* Focused-client edge labels (session edges only, not egress) */}
-            {isFocusedEdge && !e.isEgress && lp && (
-              <g pointerEvents="none">
-                {srcIp && (
-                  <g>
-                    <rect x={lp.src.x - 50} y={lp.src.y - 9} width={100} height={11} rx="2"
-                      fill="rgba(3,5,8,.82)" stroke="rgba(255,255,255,.08)" />
-                    <text x={lp.src.x} y={lp.src.y} textAnchor="middle"
-                      fill="rgba(255,255,255,.75)" fontSize="7.5" fontFamily="'JetBrains Mono',monospace">
-                      <tspan fill="rgba(255,255,255,.35)">src  </tspan>{srcIp}
-                    </text>
-                  </g>
+                {/* Default labels — hidden when client is focused or on egress edges */}
+                {interactive && !isSel && !isFocusedEdge && !e.isEgress && count > 1 && (
+                  <EdgeLabel x={midX} y={midY} text={`${count} sessions`} color="rgba(255,255,255,.55)" />
                 )}
-                {dstIp && (
-                  <g>
-                    <rect x={lp.dst.x - 50} y={lp.dst.y - 9} width={100} height={11} rx="2"
-                      fill="rgba(3,5,8,.82)" stroke="rgba(255,255,255,.08)" />
-                    <text x={lp.dst.x} y={lp.dst.y} textAnchor="middle"
-                      fill="rgba(255,255,255,.75)" fontSize="7.5" fontFamily="'JetBrains Mono',monospace">
-                      <tspan fill="rgba(255,255,255,.35)">dst  </tspan>{dstIp}
-                    </text>
-                  </g>
+                {interactive && !isSel && !isFocusedEdge && !e.isEgress && count === 1 && e.setup_ms > 0 && (
+                  <EdgeLabel x={midX} y={midY} text={`net ${e.net_id} · ${e.setup_ms}ms`} color="rgba(255,255,255,.4)" />
                 )}
-                {focusedNetId !== null && (
-                  <g>
-                    <rect x={lp.mid.x - 60} y={lp.mid.y - 15} width={120} height={session ? 32 : 16} rx="4"
-                      fill="rgba(3,5,8,.88)" stroke="rgba(255,255,255,.07)" />
-                    <text x={lp.mid.x} y={lp.mid.y - 6} textAnchor="middle"
-                      fill="rgba(91,156,246,.9)" fontSize="8" fontWeight="600">
-                      VNI {focusedNetId}
-                    </text>
-                    {session && (
-                      <>
-                        <text x={lp.mid.x} y={lp.mid.y + 4} textAnchor="middle"
-                          fill="rgba(255,255,255,.5)" fontSize="7" fontFamily="'JetBrains Mono',monospace">
-                          <tspan fill="rgba(255,255,255,.3)">src  </tspan>{session.client_net}
+
+                {/* Focused-client edge labels (session edges only, not egress) */}
+                {isFocusedEdge && !e.isEgress && lp && (
+                  <g pointerEvents="none">
+                    {srcIp && (
+                      <g>
+                        <rect x={lp.src.x - 50} y={lp.src.y - 9} width={100} height={11} rx="2"
+                          fill="rgba(3,5,8,.82)" stroke="rgba(255,255,255,.08)" />
+                        <text x={lp.src.x} y={lp.src.y} textAnchor="middle"
+                          fill="rgba(255,255,255,.75)" fontSize="7.5" fontFamily="'JetBrains Mono',monospace">
+                          <tspan fill="rgba(255,255,255,.35)">src  </tspan>{srcIp}
                         </text>
-                        <text x={lp.mid.x} y={lp.mid.y + 13} textAnchor="middle"
-                          fill="rgba(255,255,255,.5)" fontSize="7" fontFamily="'JetBrains Mono',monospace">
-                          <tspan fill="rgba(255,255,255,.3)">dst  </tspan>{session.server_net}
+                      </g>
+                    )}
+                    {dstIp && (
+                      <g>
+                        <rect x={lp.dst.x - 50} y={lp.dst.y - 9} width={100} height={11} rx="2"
+                          fill="rgba(3,5,8,.82)" stroke="rgba(255,255,255,.08)" />
+                        <text x={lp.dst.x} y={lp.dst.y} textAnchor="middle"
+                          fill="rgba(255,255,255,.75)" fontSize="7.5" fontFamily="'JetBrains Mono',monospace">
+                          <tspan fill="rgba(255,255,255,.35)">dst  </tspan>{dstIp}
                         </text>
-                      </>
+                      </g>
+                    )}
+                    {focusedNetId !== null && (
+                      <g>
+                        <rect x={lp.mid.x - 60} y={lp.mid.y - 15} width={120} height={session ? 32 : 16} rx="4"
+                          fill="rgba(3,5,8,.88)" stroke="rgba(255,255,255,.07)" />
+                        <text x={lp.mid.x} y={lp.mid.y - 6} textAnchor="middle"
+                          fill="rgba(91,156,246,.9)" fontSize="8" fontWeight="600">
+                          VNI {focusedNetId}
+                        </text>
+                        {session && (
+                          <>
+                            <text x={lp.mid.x} y={lp.mid.y + 4} textAnchor="middle"
+                              fill="rgba(255,255,255,.5)" fontSize="7" fontFamily="'JetBrains Mono',monospace">
+                              <tspan fill="rgba(255,255,255,.3)">src  </tspan>{session.client_net}
+                            </text>
+                            <text x={lp.mid.x} y={lp.mid.y + 13} textAnchor="middle"
+                              fill="rgba(255,255,255,.5)" fontSize="7" fontFamily="'JetBrains Mono',monospace">
+                              <tspan fill="rgba(255,255,255,.3)">dst  </tspan>{session.server_net}
+                            </text>
+                          </>
+                        )}
+                      </g>
                     )}
                   </g>
                 )}
               </g>
-            )}
-          </g>
-        );
-      })}
+            );
+          })}
 
       {/* Nodes */}
-      {nodes.map((n, ni) => {
-        const p = pos.get(n.id);
-        if (!p) return null;
-        const isSel = n.id === selectedNodeId;
-        const nodeDimmed = focusedNetIds != null && !focusedNodeIds.has(n.id);
-        const clickHandler = onNodeClick ? (ev: { stopPropagation(): void }) => { ev.stopPropagation(); onNodeClick(n.id); } : undefined;
-        const clipId = `nc-${ni}`;
-
-        if (n.kind === 'internet') {
-          return (
-            <g key={INTERNET_ID} onClick={clickHandler} style={{ cursor: onNodeClick ? 'pointer' : 'default', opacity: nodeDimmed ? 0.12 : 1 }}>
-              {isSel && (
-                <rect x={p.x - 3} y={p.y - 3} width={INET_W + 6} height={INET_H + 6} rx="14"
-                  fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
-              )}
-              <rect x={p.x} y={p.y} width={INET_W} height={INET_H} rx="11"
-                fill="rgba(91,156,246,.05)" stroke="rgba(91,156,246,.2)"
-                strokeWidth="1" strokeDasharray="4 3" filter="url(#gT)" />
-              <text x={p.x + INET_W / 2} y={p.y + INET_H / 2 + 4}
-                textAnchor="middle" fill="rgba(91,156,246,.7)" fontSize="9.5" fontWeight="600" pointerEvents="none">
-                ⬡ internet
-              </text>
-            </g>
-          );
-        }
-
-        if (n.kind === 'proxy') {
-          if (n.placeholder) {
-            return (
-              <g key={n.id} style={{ opacity: nodeDimmed ? 0.12 : 1 }}>
-                <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
-                  fill="rgba(255,255,255,.02)" stroke="rgba(255,255,255,.12)"
-                  strokeWidth="1" strokeDasharray="5 3" />
-                <circle cx={p.x + 15} cy={p.y + 22} r="3.5" fill="none" stroke="rgba(255,255,255,.25)" strokeWidth="1.5" />
-                <g clipPath={`url(#${clipId})`} pointerEvents="none">
-                  <defs>
-                    <clipPath id={clipId}>
-                      <rect x={p.x + 4} y={p.y + 2} width={NODE_W - 8} height={NODE_H - 4} />
-                    </clipPath>
-                  </defs>
-                  <text x={p.x + 27} y={p.y + 20} fill="rgba(255,255,255,.35)" fontSize="9.5" fontWeight="500">proxy</text>
-                  <text x={p.x + 27} y={p.y + 32} fill="rgba(255,255,255,.25)" fontSize="7.5">no active connections</text>
-                </g>
-              </g>
-            );
-          }
-          return (
-            <g key={n.id} onClick={clickHandler} style={{ cursor: onNodeClick ? 'pointer' : 'default', opacity: nodeDimmed ? 0.12 : 1 }}>
-              <defs>
-                <clipPath id={clipId}>
-                  <rect x={p.x + 4} y={p.y + 2} width={NODE_W - 8} height={NODE_H - 4} />
-                </clipPath>
-              </defs>
-              {isSel && (
-                <rect x={p.x - 3} y={p.y - 3} width={NODE_W + 6} height={NODE_H + 6} rx="10"
-                  fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
-              )}
-              <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
-                fill="rgba(251,191,36,.06)" stroke="rgba(251,191,36,.4)"
-                strokeWidth="1" strokeDasharray="5 3" filter="url(#gT)" />
-              <circle cx={p.x + 15} cy={p.y + 22} r="3.5" fill="#fbbf24" />
-              <g clipPath={`url(#${clipId})`} pointerEvents="none">
-                <text x={p.x + 27} y={p.y + 20} fill="rgba(251,191,36,.9)" fontSize="9.5" fontWeight="500">proxy</text>
-                <text x={p.x + 27} y={p.y + 32} fill="rgba(255,255,255,.4)" fontSize="8" fontFamily="'JetBrains Mono',monospace">{n.id}</text>
-              </g>
-            </g>
-          );
-        }
-
-        const color = n.registered ? '#34d399' : '#f87171';
-        const strokeColor = n.registered ? 'rgba(52,211,153,.3)' : 'rgba(248,113,113,.2)';
-        const ip = nodeIps.get(n.id);
-        return (
-          <g key={n.id} onClick={clickHandler} style={{ cursor: onNodeClick ? 'pointer' : 'default', opacity: nodeDimmed ? 0.12 : 1 }}>
-            <title>{n.id}</title>
-            <defs>
-              <clipPath id={clipId}>
-                <rect x={p.x + 4} y={p.y + 2} width={NODE_W - 8} height={NODE_H - 4} />
-              </clipPath>
-            </defs>
-            {isSel && (
-              <rect x={p.x - 3} y={p.y - 3} width={NODE_W + 6} height={NODE_H + 6} rx="10"
-                fill="none" stroke="rgba(91,156,246,.6)" strokeWidth="1.5" />
-            )}
-            <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx="8"
-              fill="rgba(255,255,255,.04)" stroke={strokeColor} strokeWidth="1" filter="url(#gT)" />
-            <circle cx={p.x + 15} cy={p.y + 17} r="3.5" fill={color} />
-            <g clipPath={`url(#${clipId})`} pointerEvents="none">
-              <text x={p.x + 27} y={p.y + 20} fill="rgba(255,255,255,.85)" fontSize="9.5" fontWeight="500">{n.id}</text>
-              {ip && (
-                <text x={p.x + 27} y={p.y + 31} fill="rgba(255,255,255,.35)" fontSize="8" fontFamily="'JetBrains Mono',monospace">{ip}</text>
-              )}
-              <text x={p.x + 27} y={p.y + (ip ? 42 : 31)} fill="rgba(255,255,255,.3)" fontSize="7.5">
-                {n.registered ? `${n.active_replica_count}/${n.replica_count} active` : 'unregistered'}
-                {n.registered && n.paused_replica_count > 0 ? ` · ${n.paused_replica_count} paused` : ''}
-                {n.entry_point ? ' · entry' : ''}
-              </text>
-            </g>
-          </g>
-        );
-      })}
+      {nodes.map((n, ni) => renderNode(n, String(ni)))}
     </svg>
   );
 }

--- a/members/nullnet-server/ui/src/components/topology/TopologyMatrix.tsx
+++ b/members/nullnet-server/ui/src/components/topology/TopologyMatrix.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import type { GraphJson } from '../../types';
+import type { TopoNode, TopoEdge } from './types';
+import { buildTopoGraph } from './layout';
+
+interface Props {
+  graph: GraphJson;
+  selectedNodeId?: string | null;
+  selectedEdgeKey?: string | null;
+  onNodeClick?: (id: string) => void;
+  onEdgeClick?: (fromId: string, toId: string, edgeIndices: number[]) => void;
+  onBgClick?: () => void;
+}
+
+const CELL = 26;
+const LABEL_COL_W = 150;
+const HEADER_ROW_H = 150;
+
+function shortLabel(id: string): string {
+  return id.length > 18 ? `${id.slice(0, 17)}…` : id;
+}
+
+function kindColor(n: TopoNode): string {
+  if (n.kind === 'proxy') return 'rgba(251,191,36,.85)';
+  return n.kind === 'service' && n.registered ? 'rgba(52,211,153,.85)' : 'rgba(248,113,113,.7)';
+}
+
+function edgeColor(e: TopoEdge): string {
+  return e.isEgress ? 'rgba(167,139,250,.75)' : e.isProxyHop ? 'rgba(251,191,36,.7)' : 'rgba(91,156,246,.75)';
+}
+
+// Adjacency-matrix view of the same graph the other layouts draw as a
+// node-link diagram: rows/cols ordered proxies-then-services (internet
+// omitted — every proxy trivially connects to it, an uninformative row/col),
+// filled cell = row → col has an edge. Zero edge crossings by construction,
+// at the cost of not reading as a path the way the node-link views do.
+export default function TopologyMatrix({
+  graph, selectedNodeId = null, selectedEdgeKey = null, onNodeClick, onEdgeClick, onBgClick,
+}: Props) {
+  const { nodes, edges } = buildTopoGraph(graph);
+  const order = nodes
+    .filter(n => n.kind !== 'internet')
+    .sort((a, b) => (a.kind === b.kind ? a.id.localeCompare(b.id) : a.kind === 'proxy' ? -1 : 1));
+  const indexOf = new Map(order.map((n, i) => [n.id, i]));
+
+  const edgeByPair = new Map<string, TopoEdge>();
+  for (const e of edges) {
+    if (e.isInternetEdge) continue;
+    edgeByPair.set(`${e.from}\0${e.to}`, e);
+  }
+
+  // The row/column crosshair tracks two INDEPENDENT indices — hovering a cell
+  // highlights its own row and column (which are different, off-diagonal
+  // indices), while hovering a row/column label or selecting a node
+  // highlights that single node's row and column (necessarily the same
+  // index, so the crosshair sits on the diagonal in that case only).
+  const [hoveredCell, setHoveredCell] = useState<{ rowId: string; colId: string } | null>(null);
+  let hi = -1, hj = -1;
+  if (hoveredCell) {
+    hi = indexOf.get(hoveredCell.rowId) ?? -1;
+    hj = indexOf.get(hoveredCell.colId) ?? -1;
+  } else if (selectedNodeId) {
+    hi = hj = indexOf.get(selectedNodeId) ?? -1;
+  } else if (selectedEdgeKey) {
+    const e = edgeByPair.get(selectedEdgeKey);
+    if (e) { hi = indexOf.get(e.from) ?? -1; hj = indexOf.get(e.to) ?? -1; }
+  }
+  const hasHighlight = hi >= 0 || hj >= 0;
+
+  const w = LABEL_COL_W + order.length * CELL;
+  const h = HEADER_ROW_H + order.length * CELL;
+
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} xmlns="http://www.w3.org/2000/svg"
+      style={{ width: '100%', display: 'block', fontFamily: "'Plus Jakarta Sans',sans-serif" }}>
+      {onBgClick && <rect x={0} y={0} width={w} height={h} fill="transparent" onClick={onBgClick} />}
+
+      {order.map((_, i) => (
+        <line key={`h${i}`} x1={LABEL_COL_W} y1={HEADER_ROW_H + i * CELL} x2={w} y2={HEADER_ROW_H + i * CELL}
+          stroke="rgba(255,255,255,.06)" />
+      ))}
+      {order.map((_, j) => (
+        <line key={`v${j}`} x1={LABEL_COL_W + j * CELL} y1={0} x2={LABEL_COL_W + j * CELL} y2={h}
+          stroke="rgba(255,255,255,.06)" />
+      ))}
+
+      {hi >= 0 && (
+        <rect x={0} y={HEADER_ROW_H + hi * CELL} width={w} height={CELL}
+          fill="rgba(91,156,246,.06)" pointerEvents="none" />
+      )}
+      {hj >= 0 && (
+        <rect x={LABEL_COL_W + hj * CELL} y={0} width={CELL} height={h}
+          fill="rgba(91,156,246,.06)" pointerEvents="none" />
+      )}
+
+      {/* Every (row, col) position is hoverable — not just the ones with an
+          edge — so pointing anywhere in the grid tells you which row/column
+          it belongs to. Diagonal cells stay content-free (no self-edges). */}
+      {order.map((rowNode, i) => order.map((colNode, j) => {
+        if (i === j) return null;
+        const key = `${rowNode.id}\0${colNode.id}`;
+        const e = edgeByPair.get(key);
+        const isSel = selectedEdgeKey === key;
+        const dimmed = hasHighlight && i !== hi && j !== hj;
+        const x = LABEL_COL_W + j * CELL, y = HEADER_ROW_H + i * CELL;
+        const count = e?.originalIndices.length ?? 0;
+        return (
+          <g key={key}
+            onMouseEnter={() => setHoveredCell({ rowId: rowNode.id, colId: colNode.id })}
+            onMouseLeave={() => setHoveredCell(null)}
+            onClick={e && onEdgeClick ? (ev: React.MouseEvent) => { ev.stopPropagation(); onEdgeClick(e.from, e.to, e.originalIndices); } : undefined}
+            style={{ cursor: e && onEdgeClick ? 'pointer' : 'default', opacity: dimmed ? 0.15 : 1 }}>
+            <rect x={x} y={y} width={CELL} height={CELL} fill="transparent" />
+            {e && (
+              <>
+                <title>{`${e.from} → ${e.to}${count > 1 ? ` (${count} sessions)` : ''}`}</title>
+                <rect x={x + 2} y={y + 2} width={CELL - 4} height={CELL - 4} rx="3"
+                  fill={edgeColor(e)} opacity={isSel ? 1 : 0.7}
+                  stroke={isSel ? 'rgba(91,156,246,.9)' : 'none'} strokeWidth={isSel ? 1.5 : 0} />
+                {count > 1 && (
+                  <text x={x + CELL / 2} y={y + CELL / 2 + 3} textAnchor="middle"
+                    fill="rgba(3,5,8,.85)" fontSize="8" fontWeight="700" pointerEvents="none">
+                    {count}
+                  </text>
+                )}
+              </>
+            )}
+          </g>
+        );
+      }))}
+
+      {order.map((n, i) => (
+        <g key={`r${n.id}`}
+          onClick={onNodeClick ? (ev: React.MouseEvent) => { ev.stopPropagation(); onNodeClick(n.id); } : undefined}
+          onMouseEnter={() => setHoveredCell({ rowId: n.id, colId: n.id })} onMouseLeave={() => setHoveredCell(null)}
+          style={{ cursor: onNodeClick ? 'pointer' : 'default' }}>
+          <rect x={0} y={HEADER_ROW_H + i * CELL} width={LABEL_COL_W} height={CELL} fill="transparent" />
+          <circle cx={10} cy={HEADER_ROW_H + i * CELL + CELL / 2} r="3" fill={kindColor(n)} />
+          <text x={20} y={HEADER_ROW_H + i * CELL + CELL / 2 + 3}
+            fill={n.id === selectedNodeId ? 'rgba(91,156,246,.95)' : 'rgba(255,255,255,.7)'}
+            fontSize="9" fontFamily="'JetBrains Mono',monospace">
+            {shortLabel(n.id)}
+          </text>
+        </g>
+      ))}
+
+      {order.map((n, j) => {
+        const x = LABEL_COL_W + j * CELL + CELL / 2;
+        const y = HEADER_ROW_H - 8;
+        return (
+          <g key={`c${n.id}`}
+            onClick={onNodeClick ? (ev: React.MouseEvent) => { ev.stopPropagation(); onNodeClick(n.id); } : undefined}
+            onMouseEnter={() => setHoveredCell({ rowId: n.id, colId: n.id })} onMouseLeave={() => setHoveredCell(null)}
+            style={{ cursor: onNodeClick ? 'pointer' : 'default' }}>
+            <rect x={x - CELL / 2} y={0} width={CELL} height={HEADER_ROW_H} fill="transparent" />
+            <g transform={`rotate(-45, ${x}, ${y})`}>
+              <circle cx={x} cy={y} r="3" fill={kindColor(n)} />
+              <text x={x + 6} y={y + 3}
+                fill={n.id === selectedNodeId ? 'rgba(91,156,246,.95)' : 'rgba(255,255,255,.7)'}
+                fontSize="9" fontFamily="'JetBrains Mono',monospace">
+                {shortLabel(n.id)}
+              </text>
+            </g>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/members/nullnet-server/ui/src/components/topology/ZoomFrame.tsx
+++ b/members/nullnet-server/ui/src/components/topology/ZoomFrame.tsx
@@ -14,6 +14,7 @@ interface Props {
   fill?: boolean;
   anchor?: 'center' | 'top-left';
   grow?: boolean;
+  overlay?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -31,7 +32,7 @@ function computeHome(cw: number, ch: number, contentH: number, anchor: 'center' 
   return { scale, tx, ty };
 }
 
-export default function ZoomFrame({ height, fill, anchor = 'center', grow, children }: Props) {
+export default function ZoomFrame({ height, fill, anchor = 'center', grow, overlay, children }: Props) {
   const [zoom, setZoom] = useState<ZoomState>({ scale: 1, tx: 0, ty: 0 });
   const dragging = useRef<{ startX: number; startY: number; startTx: number; startTy: number } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -145,6 +146,11 @@ export default function ZoomFrame({ height, fill, anchor = 'center', grow, child
           {children}
         </div>
       </div>
+      {overlay && (
+        <div style={{ position: 'absolute', top: 10, right: 10 }}>
+          {overlay}
+        </div>
+      )}
       {!isDefault && (
         <button
           onClick={resetZoom}

--- a/members/nullnet-server/ui/src/components/topology/layout.ts
+++ b/members/nullnet-server/ui/src/components/topology/layout.ts
@@ -60,7 +60,7 @@ export function buildTopoGraph(graph: GraphJson): { nodes: TopoNode[]; edges: To
   return { nodes, edges: [...inetEdges, ...edgeMap.values(), ...egressMap.values()] };
 }
 
-export function layoutNodes(nodes: TopoNode[], edges: TopoEdge[]): Map<string, Pos> {
+export function layoutNodes(nodes: TopoNode[], edges: TopoEdge[]): { pos: Map<string, Pos>; waypoints: Map<string, Pos[]> } {
   const hasInternet = nodes.some(n => n.kind === 'internet');
   const proxyNodes = nodes.filter(n => n.kind === 'proxy');
   const serviceNodes = nodes.filter(n => n.kind === 'service');
@@ -136,76 +136,246 @@ export function layoutNodes(nodes: TopoNode[], edges: TopoEdge[]): Map<string, P
     if (!byLayer.has(l)) byLayer.set(l, []);
     byLayer.get(l)!.push(id);
   }
-  for (const l of [...byLayer.keys()].sort((a, b) => a - b)) {
-    const row = byLayer.get(l)!.sort();
+
+  // Within-layer ordering: minimize edge crossings with a barycenter heuristic
+  // instead of a fixed alphabetical sort. Alphabetical order is still the seed
+  // (and the tiebreak), so output stays deterministic across the 5s poll.
+  const order = new Map<number, string[]>();
+  for (const [l, ids] of byLayer) order.set(l, [...ids].sort());
+  const maxLayer = Math.max(0, ...order.keys());
+
+  // Barycenters are computed over the FULL (non-DFS-stripped) adjacency, so a
+  // back edge dropped only for layering purposes still pulls its endpoints
+  // toward each other visually.
+  const allNeighbors = new Map<string, Set<string>>();
+  for (const n of serviceNodes) allNeighbors.set(n.id, new Set([...out.get(n.id)!, ...inc.get(n.id)!]));
+
+  // Layer 0 has no layer above it — its "down" reference is the fixed proxy
+  // row instead, so entry services line up under the proxy they actually
+  // enter through.
+  const proxySet = new Set(proxyNodes.map(n => n.id));
+  const proxyIndexById = new Map(proxyNodes.map((n, i) => [n.id, i]));
+  const svcProxyNeighbors = new Map<string, Set<string>>();
+  for (const n of serviceNodes) svcProxyNeighbors.set(n.id, new Set());
+  for (const e of edges) {
+    if (svcSet.has(e.from) && proxySet.has(e.to)) svcProxyNeighbors.get(e.from)!.add(e.to);
+    if (proxySet.has(e.from) && svcSet.has(e.to)) svcProxyNeighbors.get(e.to)!.add(e.from);
+  }
+
+  // Long-edge routing: any edge whose endpoints land more than one layer
+  // apart gets a chain of invisible waypoint nodes, one per intermediate
+  // layer. They're added to `order` and `allNeighbors` just like real nodes,
+  // so the crossing-reduction sweep below pushes real nodes out of the way
+  // of the edge instead of letting it cut a straight line through them.
+  // Proxies sit at virtual layer -1 for this purpose only (their own row is
+  // fixed, never reordered). Egress edges participate too — a service several
+  // layers deep still needs to reach the proxy row, and without a reserved
+  // lane its bow-right routing has to sweep across whatever sits in between.
+  // Internet edges are routed separately and don't participate.
+  const waypointIds = new Map<string, string[]>(); // edge key -> dummy ids, source→dest order
+  const effLayer = (id: string): number | null => (proxySet.has(id) ? -1 : layer.get(id) ?? null);
+  let dummySeq = 0;
+  for (const e of edges) {
+    if (e.isInternetEdge) continue;
+    const fromOk = svcSet.has(e.from) || proxySet.has(e.from);
+    const toOk = svcSet.has(e.to) || proxySet.has(e.to);
+    if (!fromOk || !toOk) continue;
+    const lu = effLayer(e.from), lv = effLayer(e.to);
+    if (lu === null || lv === null) continue;
+    const lo = Math.min(lu, lv), hi = Math.max(lu, lv);
+    if (hi - lo <= 1) continue; // adjacent (or same) layer — no dummies needed
+
+    const chainLayers: number[] = [];
+    for (let l = Math.max(lo + 1, 0); l < hi; l++) chainLayers.push(l);
+    if (!chainLayers.length) continue;
+    if (lu > lv) chainLayers.reverse(); // keep the chain in source→dest order
+
+    const ids = chainLayers.map(l => {
+      const id = `__wp${dummySeq++}`;
+      order.get(l)!.push(id);
+      return id;
+    });
+    const chain = [e.from, ...ids, e.to];
+    for (let i = 0; i < chain.length - 1; i++) {
+      const a = chain[i], b = chain[i + 1];
+      if (!allNeighbors.has(a)) allNeighbors.set(a, new Set());
+      if (!allNeighbors.has(b)) allNeighbors.set(b, new Set());
+      allNeighbors.get(a)!.add(b);
+      allNeighbors.get(b)!.add(a);
+    }
+    waypointIds.set(`${e.from}\0${e.to}`, ids);
+  }
+
+  const indexOf = (ids: string[]): Map<string, number> => {
+    const m = new Map<string, number>();
+    ids.forEach((id, i) => m.set(id, i));
+    return m;
+  };
+
+  // Reorders one layer against a fixed reference layer's current positions.
+  // Nodes with no neighbor in the reference layer keep their current index
+  // (as their "barycenter"), so disconnected nodes don't jump around.
+  const reorderLayer = (l: number, refIndex: Map<string, number>, neighborsOf: (id: string) => Set<string>) => {
+    const ids = order.get(l);
+    if (!ids || ids.length < 2) return;
+    const prevIndex = indexOf(ids);
+    const keyed = ids.map(id => {
+      const refIdxs = [...neighborsOf(id)].map(n => refIndex.get(n)).filter((v): v is number => v !== undefined);
+      const bary = refIdxs.length ? refIdxs.reduce((a, b) => a + b, 0) / refIdxs.length : prevIndex.get(id)!;
+      return { id, bary };
+    });
+    keyed.sort((a, b) => a.bary - b.bary || a.id.localeCompare(b.id));
+    order.set(l, keyed.map(k => k.id));
+  };
+
+  const SWEEPS = 4;
+  for (let s = 0; s < SWEEPS; s++) {
+    if (s % 2 === 0) {
+      for (let l = 0; l <= maxLayer; l++) {
+        // A waypoint dummy has no entry in svcProxyNeighbors (that map is
+        // only ever populated for real services) — falling back to
+        // allNeighbors picks up the proxy id linked in via the chain above.
+        if (l === 0) reorderLayer(l, proxyIndexById, id => {
+          const svc = svcProxyNeighbors.get(id);
+          return svc?.size ? svc : (allNeighbors.get(id) ?? new Set());
+        });
+        else reorderLayer(l, indexOf(order.get(l - 1) ?? []), id => allNeighbors.get(id) ?? new Set());
+      }
+    } else {
+      for (let l = maxLayer; l >= 0; l--) {
+        reorderLayer(l, indexOf(order.get(l + 1) ?? []), id => allNeighbors.get(id) ?? new Set());
+      }
+    }
+  }
+
+  for (const l of [...order.keys()].sort((a, b) => a - b)) {
+    const row = order.get(l)!;
     row.forEach((id, i) => pos.set(id, { x: H_GAP + i * (NODE_W + H_GAP), y: svcOffsetY + l * (NODE_H + V_GAP) }));
   }
-  return pos;
+
+  const waypoints = new Map<string, Pos[]>();
+  for (const [edgeKey, ids] of waypointIds) {
+    waypoints.set(edgeKey, ids.map(id => pos.get(id)!));
+  }
+  return { pos, waypoints };
+}
+
+// Every node is NODE_W x NODE_H except the internet node, which is its own
+// (smaller) pill size — shared by any layout math that needs real node extents.
+export function nodeSize(node: TopoNode | undefined): { w: number; h: number } {
+  return node?.kind === 'internet' ? { w: INET_W, h: INET_H } : { w: NODE_W, h: NODE_H };
 }
 
 export function svgDims(pos: Map<string, Pos>, nodes: TopoNode[]): { w: number; h: number } {
   const nodeById = new Map(nodes.map(n => [n.id, n]));
   let maxX = 0, maxY = 0;
   for (const [id, { x, y }] of pos.entries()) {
-    const n = nodeById.get(id);
-    const nw = n?.kind === 'internet' ? INET_W : NODE_W;
-    const nh = n?.kind === 'internet' ? INET_H : NODE_H;
+    const { w: nw, h: nh } = nodeSize(nodeById.get(id));
     maxX = Math.max(maxX, x + nw);
     maxY = Math.max(maxY, y + nh);
   }
   return { w: maxX + H_GAP, h: maxY + V_GAP };
 }
 
-export function edgePath(from: Pos, to: Pos): string {
+// `offset` shifts both endpoints sideways (vertical routing) or up/down
+// (horizontal routing) by the same amount — used to pull a mutual pair
+// (A→B and B→A both present, e.g. a two-node cycle) apart into two parallel
+// tracks. Without it, the midpoint-symmetric formula below puts both
+// directions' curves — and their labels — on the exact same line.
+export function edgePath(from: Pos, to: Pos, offset = 0): string {
   const fromMidY = from.y + NODE_H / 2;
   const toMidY = to.y + NODE_H / 2;
   if (toMidY > fromMidY + NODE_H) {
-    const x1 = from.x + NODE_W / 2, y1 = from.y + NODE_H;
-    const x2 = to.x + NODE_W / 2, y2 = to.y;
+    const x1 = from.x + NODE_W / 2 + offset, y1 = from.y + NODE_H;
+    const x2 = to.x + NODE_W / 2 + offset, y2 = to.y;
     const cy = (y1 + y2) / 2;
     return `M ${x1} ${y1} C ${x1} ${cy}, ${x2} ${cy}, ${x2} ${y2}`;
   }
   if (fromMidY > toMidY + NODE_H) {
-    const x1 = from.x + NODE_W / 2, y1 = from.y;
-    const x2 = to.x + NODE_W / 2, y2 = to.y + NODE_H;
+    const x1 = from.x + NODE_W / 2 + offset, y1 = from.y;
+    const x2 = to.x + NODE_W / 2 + offset, y2 = to.y + NODE_H;
     const cy = (y1 + y2) / 2;
     return `M ${x1} ${y1} C ${x1} ${cy}, ${x2} ${cy}, ${x2} ${y2}`;
   }
   const goRight = to.x >= from.x;
   const x1 = goRight ? from.x + NODE_W : from.x;
-  const y1 = from.y + NODE_H / 2;
+  const y1 = from.y + NODE_H / 2 + offset;
   const x2 = goRight ? to.x : to.x + NODE_W;
-  const y2 = to.y + NODE_H / 2;
+  const y2 = to.y + NODE_H / 2 + offset;
   const cx = (x1 + x2) / 2;
   return `M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}`;
+}
+
+// Label anchor matching edgePath's own routing (including `offset`) — mirrors
+// its branching so a mutual pair's two labels land on their own offset curve
+// instead of both sitting at the un-offset geometric midpoint.
+export function edgeMidpoint(from: Pos, to: Pos, offset = 0): Pos {
+  const fromMidY = from.y + NODE_H / 2;
+  const toMidY = to.y + NODE_H / 2;
+  if (toMidY > fromMidY + NODE_H || fromMidY > toMidY + NODE_H) {
+    return { x: (from.x + to.x) / 2 + NODE_W / 2 + offset, y: (from.y + to.y) / 2 + NODE_H / 2 };
+  }
+  const goRight = to.x >= from.x;
+  const x1 = goRight ? from.x + NODE_W : from.x;
+  const x2 = goRight ? to.x : to.x + NODE_W;
+  return { x: (x1 + x2) / 2, y: (from.y + to.y) / 2 + NODE_H / 2 + offset };
+}
+
+// Multi-hop version of edgePath's downward/upward case, routed through the
+// waypoint dummy positions layoutNodes() reserved for this edge — one smooth
+// piecewise-cubic path through each intermediate layer's actual slot, instead
+// of a single curve that ignores what sits in between. Waypoints are pure
+// points (no box to attach to), so only the real `from`/`to` ends get the
+// box-edge offset; every waypoint contributes its exact center.
+export function longEdgePath(from: Pos, waypoints: Pos[], to: Pos): string {
+  const downward = to.y >= from.y;
+  const centerOf = (p: Pos, isFirst: boolean, isLast: boolean) => ({
+    x: p.x + NODE_W / 2,
+    y: isFirst ? (downward ? p.y + NODE_H : p.y)
+      : isLast ? (downward ? p.y : p.y + NODE_H)
+      : p.y + NODE_H / 2,
+  });
+  const points = [from, ...waypoints, to];
+  const centers = points.map((p, i) => centerOf(p, i === 0, i === points.length - 1));
+  let d = `M ${centers[0].x} ${centers[0].y}`;
+  for (let i = 0; i < centers.length - 1; i++) {
+    const { x: x1, y: y1 } = centers[i], { x: x2, y: y2 } = centers[i + 1];
+    const cy = (y1 + y2) / 2;
+    d += ` C ${x1} ${cy}, ${x2} ${cy}, ${x2} ${y2}`;
+  }
+  return d;
 }
 
 // Positions for per-edge labels when a client is focused.
 // src/dst are placed just outside the node endpoints; mid is the curve midpoint.
 type TextAnchor = 'start' | 'middle' | 'end';
 
-export function edgeLabelPoints(from: Pos, to: Pos): {
+export function edgeLabelPoints(
+  from: Pos, to: Pos,
+  fromSize: { w: number; h: number } = { w: NODE_W, h: NODE_H },
+  toSize: { w: number; h: number } = { w: NODE_W, h: NODE_H },
+): {
   src: { x: number; y: number; anchor: TextAnchor };
   dst: { x: number; y: number; anchor: TextAnchor };
   mid: { x: number; y: number };
 } {
-  const fromMidY = from.y + NODE_H / 2;
-  const toMidY = to.y + NODE_H / 2;
+  const fromMidY = from.y + fromSize.h / 2;
+  const toMidY = to.y + toSize.h / 2;
 
-  if (toMidY > fromMidY + NODE_H) {
+  if (toMidY > fromMidY + fromSize.h) {
     // downward — exits bottom-center, enters top-center
-    const x1 = from.x + NODE_W / 2, y1 = from.y + NODE_H;
-    const x2 = to.x + NODE_W / 2,   y2 = to.y;
+    const x1 = from.x + fromSize.w / 2, y1 = from.y + fromSize.h;
+    const x2 = to.x + toSize.w / 2,     y2 = to.y;
     return {
       src: { x: x1, y: y1 + 10, anchor: 'middle' },
       dst: { x: x2, y: y2 - 4,  anchor: 'middle' },
       mid: { x: (x1 + x2) / 2,  y: (y1 + y2) / 2 },
     };
   }
-  if (fromMidY > toMidY + NODE_H) {
+  if (fromMidY > toMidY + toSize.h) {
     // upward — exits top-center, enters bottom-center
-    const x1 = from.x + NODE_W / 2, y1 = from.y;
-    const x2 = to.x + NODE_W / 2,   y2 = to.y + NODE_H;
+    const x1 = from.x + fromSize.w / 2, y1 = from.y;
+    const x2 = to.x + toSize.w / 2,     y2 = to.y + toSize.h;
     return {
       src: { x: x1, y: y1 - 4,  anchor: 'middle' },
       dst: { x: x2, y: y2 + 10, anchor: 'middle' },
@@ -213,11 +383,11 @@ export function edgeLabelPoints(from: Pos, to: Pos): {
     };
   }
   // horizontal — exits left/right side; stack src above and dst below the VNI box
-  // to avoid all three labels colliding in the narrow H_GAP between nodes.
-  const x1 = (to.x >= from.x ? from.x + NODE_W : from.x);
-  const y1 = from.y + NODE_H / 2;
-  const x2 = (to.x >= from.x ? to.x : to.x + NODE_W);
-  const y2 = to.y + NODE_H / 2;
+  // to avoid all three labels colliding in the narrow gap between nodes.
+  const x1 = (to.x >= from.x ? from.x + fromSize.w : from.x);
+  const y1 = from.y + fromSize.h / 2;
+  const x2 = (to.x >= from.x ? to.x : to.x + toSize.w);
+  const y2 = to.y + toSize.h / 2;
   const midX = (x1 + x2) / 2;
   const midY = (y1 + y2) / 2;
   return {
@@ -246,4 +416,16 @@ export function egressEdgePath(from: Pos, to: Pos): string {
   const x2 = to.x + NODE_W, y2 = to.y + NODE_H / 2;
   const bowX = Math.max(x1, x2) + EGRESS_BOW;
   return `M ${x1} ${y1} C ${bowX} ${y1}, ${bowX} ${y2}, ${x2} ${y2}`;
+}
+
+// Label anchor for an egress edge — sits at the curve's own bow peak instead
+// of a separately-guessed position, so it can't drift away from the edge it
+// labels (it previously used from.x/to.x directly instead of the +NODE_W
+// bow origin above, which could put it right on top of an unrelated edge's
+// own midpoint label). Offset up slightly so it doesn't sit exactly on that
+// midpoint even when the two happen to coincide horizontally.
+export function egressLabelPoint(from: Pos, to: Pos): { x: number; y: number } {
+  const x1 = from.x + NODE_W, x2 = to.x + NODE_W;
+  const y1 = from.y + NODE_H / 2, y2 = to.y + NODE_H / 2;
+  return { x: Math.max(x1, x2) + EGRESS_BOW, y: (y1 + y2) / 2 - 9 };
 }

--- a/members/nullnet-server/ui/src/components/topology/types.ts
+++ b/members/nullnet-server/ui/src/components/topology/types.ts
@@ -36,3 +36,9 @@ export interface TopoEdge {
   isEgress: boolean;
   originalIndices: number[];
 }
+
+// ── Layout modes ──────────────────────────────────────────────────────────────
+
+export type LayoutMode = 'layered' | 'matrix';
+
+export const LAYOUT_MODES: LayoutMode[] = ['layered', 'matrix'];

--- a/members/nullnet-server/ui/src/pages/DebugTopology.tsx
+++ b/members/nullnet-server/ui/src/pages/DebugTopology.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useRef, useState } from 'react';
+import type { GraphJson } from '../types';
+import type { LayoutMode } from '../components/topology/types';
+import ZoomFrame from '../components/topology/ZoomFrame';
+import LayoutModeToggle from '../components/topology/LayoutModeToggle';
+import TopologyGraphSvg from '../components/topology/TopologyGraphSvg';
+import TopologyMatrix from '../components/topology/TopologyMatrix';
+
+// Not linked from the sidebar — a dev tool for iterating on topology layout
+// math against arbitrary GraphJson without a running backend/stack. Reachable
+// at /debug/topology. Paste JSON, load a file, or start from one of the
+// built-in examples; the graph renders through the exact same components the
+// real Topology page uses, so nothing here can drift from production.
+
+const EXAMPLE_MINIMAL: GraphJson = {
+  nodes: [
+    { id: 'gateway', registered: true, entry_point: true, replica_count: 1, active_replica_count: 1, paused_replica_count: 0 },
+    { id: 'auth', registered: true, entry_point: false, replica_count: 1, active_replica_count: 1, paused_replica_count: 0 },
+    { id: 'orders', registered: true, entry_point: false, replica_count: 2, active_replica_count: 2, paused_replica_count: 0 },
+  ],
+  edges: [
+    { from: '203.0.113.4', via_proxy: '10.0.0.1', to: 'gateway', net_id: 1, setup_ms: 4 },
+    { from: 'gateway', to: 'auth', net_id: 2, setup_ms: 3 },
+    { from: 'gateway', to: 'orders', net_id: 3, setup_ms: 5 },
+  ],
+};
+
+// Mirrors the shape that actually triggers overlapping arrows in layered
+// mode: a proxy edge straight into a service two dependency-layers deep
+// (upload), plus a short cycle (core <-> audit) — the two patterns worth
+// stress-testing long-edge routing against.
+const EXAMPLE_DENSE: GraphJson = {
+  nodes: [
+    { id: 'gateway', registered: true, entry_point: true, replica_count: 1, active_replica_count: 1, paused_replica_count: 0 },
+    { id: 'core', registered: true, entry_point: false, replica_count: 1, active_replica_count: 1, paused_replica_count: 0 },
+    { id: 'audit', registered: true, entry_point: false, replica_count: 1, active_replica_count: 1, paused_replica_count: 0 },
+    { id: 'billing', registered: true, entry_point: false, replica_count: 1, active_replica_count: 1, paused_replica_count: 0 },
+    { id: 'upload', registered: true, entry_point: true, replica_count: 1, active_replica_count: 1, paused_replica_count: 0 },
+    { id: 'search', registered: true, entry_point: false, replica_count: 1, active_replica_count: 0, paused_replica_count: 1 },
+    { id: 'idle-svc', registered: true, entry_point: false, replica_count: 1, active_replica_count: 1, paused_replica_count: 0 },
+  ],
+  edges: [
+    { from: '203.0.113.4', via_proxy: '10.0.0.1', to: 'gateway', net_id: 1, setup_ms: 4 },
+    { from: '203.0.113.9', via_proxy: '10.0.0.1', to: 'upload', net_id: 2, setup_ms: 6 },
+    { from: 'gateway', to: 'core', net_id: 3, setup_ms: 5 },
+    { from: 'core', to: 'audit', net_id: 4, setup_ms: 3 },
+    { from: 'audit', to: 'core', net_id: 5, setup_ms: 3 },
+    { from: 'core', to: 'billing', net_id: 6, setup_ms: 4 },
+    { from: 'billing', to: 'upload', net_id: 7, setup_ms: 2 },
+    { from: 'core', to: 'search', net_id: 8, setup_ms: 4 },
+    { from: 'core', to: 'upload', net_id: 9, setup_ms: 4 },
+  ],
+};
+
+function isGraphJson(v: unknown): v is GraphJson {
+  return !!v && typeof v === 'object' && Array.isArray((v as GraphJson).nodes) && Array.isArray((v as GraphJson).edges);
+}
+
+const inputStyle: React.CSSProperties = {
+  background: 'var(--g1)', border: '1px solid var(--gb)', color: 'var(--t0)',
+  fontSize: 11, padding: '6px 10px', borderRadius: 5, cursor: 'pointer',
+};
+
+export default function DebugTopology() {
+  const [raw, setRaw] = useState(() => JSON.stringify(EXAMPLE_MINIMAL, null, 2));
+  const [graph, setGraph] = useState<GraphJson | null>(EXAMPLE_MINIMAL);
+  const [error, setError] = useState<string | null>(null);
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>('layered');
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectedEdgeKey, setSelectedEdgeKey] = useState<string | null>(null);
+  const [inspect, setInspect] = useState<unknown>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const apply = useCallback((text: string) => {
+    setRaw(text);
+    try {
+      const parsed = JSON.parse(text);
+      if (!isGraphJson(parsed)) throw new Error('JSON must have "nodes" and "edges" arrays');
+      setGraph(parsed);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  const loadFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => apply(String(reader.result ?? ''));
+    reader.readAsText(file);
+  };
+
+  const clearSelection = () => {
+    setSelectedNodeId(null);
+    setSelectedEdgeKey(null);
+    setInspect(null);
+  };
+
+  const onNodeClick = (id: string) => {
+    setSelectedNodeId(prev => (prev === id ? null : id));
+    setSelectedEdgeKey(null);
+    setInspect(graph?.nodes.find(n => n.id === id) ?? { id });
+  };
+  const onEdgeClick = (fromId: string, toId: string, edgeIndices: number[]) => {
+    const key = `${fromId}\0${toId}`;
+    setSelectedEdgeKey(prev => (prev === key ? null : key));
+    setSelectedNodeId(null);
+    setInspect(edgeIndices.map(i => graph?.edges[i]).filter(Boolean));
+  };
+
+  return (
+    <div style={{ display: 'flex', width: '100%', height: '100vh', background: 'var(--bg)', color: 'var(--t0)' }}>
+      <div style={{
+        width: 420, flexShrink: 0, display: 'flex', flexDirection: 'column',
+        borderRight: '1px solid var(--gb)', padding: 16, gap: 10, minHeight: 0,
+      }}>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 700 }}>Topology debug</div>
+          <div style={{ fontSize: 10.5, color: 'var(--t2)', marginTop: 4, lineHeight: 1.5 }}>
+            Paste a GraphJson ({'{ nodes, edges }'}), or load a file — renders through the
+            real topology components, no backend involved.
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          <button style={inputStyle} onClick={() => apply(JSON.stringify(EXAMPLE_MINIMAL, null, 2))}>minimal example</button>
+          <button style={inputStyle} onClick={() => apply(JSON.stringify(EXAMPLE_DENSE, null, 2))}>long-edge example</button>
+          <button style={inputStyle} onClick={() => fileInputRef.current?.click()}>load file…</button>
+          <input ref={fileInputRef} type="file" accept=".json,application/json" style={{ display: 'none' }}
+            onChange={e => { const f = e.target.files?.[0]; if (f) loadFile(f); e.target.value = ''; }} />
+        </div>
+
+        <textarea
+          value={raw}
+          onChange={e => apply(e.target.value)}
+          spellCheck={false}
+          style={{
+            flex: 1, minHeight: 0, resize: 'none', background: 'var(--g1)', border: '1px solid var(--gb)',
+            borderRadius: 5, color: 'var(--t0)', fontFamily: "'JetBrains Mono',monospace", fontSize: 11,
+            padding: 10, lineHeight: 1.5,
+          }}
+        />
+
+        {error && (
+          <div style={{ fontSize: 11, color: '#f87171', fontFamily: "'JetBrains Mono',monospace" }}>{error}</div>
+        )}
+
+        {inspect != null && (
+          <div style={{ borderTop: '1px solid var(--gb)', paddingTop: 8, maxHeight: 220, overflow: 'auto' }}>
+            <div style={{ fontSize: 9, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--t2)', marginBottom: 4 }}>
+              selected
+            </div>
+            <pre style={{ fontSize: 10, color: 'var(--t1)', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+              {JSON.stringify(inspect, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      <div style={{ flex: 1, position: 'relative', minWidth: 0 }}>
+        {graph && (
+          <ZoomFrame
+            height="100%"
+            fill
+            overlay={<LayoutModeToggle mode={layoutMode} onChange={setLayoutMode} />}
+          >
+            {layoutMode === 'matrix' ? (
+              <TopologyMatrix
+                graph={graph}
+                selectedNodeId={selectedNodeId}
+                selectedEdgeKey={selectedEdgeKey}
+                onNodeClick={onNodeClick}
+                onEdgeClick={onEdgeClick}
+                onBgClick={clearSelection}
+              />
+            ) : (
+              <TopologyGraphSvg
+                graph={graph}
+                selectedNodeId={selectedNodeId}
+                selectedEdgeKey={selectedEdgeKey}
+                onNodeClick={onNodeClick}
+                onEdgeClick={onEdgeClick}
+                onBgClick={clearSelection}
+              />
+            )}
+          </ZoomFrame>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Dense service meshes made the layered Topology view hard to read: edges
routinely cut straight through unrelated nodes and labels, egress edges swept
diagonally across the whole diagram to reach the proxy, and a cycle between
two nodes could draw both directions as literally the same overlapping curve
and label. This PR fixes the routing itself rather than just adding another
view on top of it, and adds an adjacency-matrix view as a genuinely different
way to read a dense graph.

## What changed

**Layered mode — long-edge routing**
Any edge that spans more than one layer (a proxy hop straight into a service
several dependency-layers deep, a deep service-to-service edge, or an egress
hop back to a distant proxy) now reserves a dummy waypoint slot in every
intermediate layer it crosses. The existing crossing-reduction sweep treats
those slots like real nodes, so it pushes actual nodes out of the way instead
of letting the edge draw a raw curve through them. Default edge labels anchor
to that same reserved slot instead of the raw endpoint midpoint, which — for
a waypoint-routed edge — could land squarely on top of an unrelated node.

**Mutual-pair separation**
`A→B` and `B→A` between the same two nodes (e.g. a two-node cycle) hit a
midpoint-symmetric formula: both directions computed the identical curve and
the identical label position, so one fully occluded the other. They now
separate into two parallel tracks — a modest bow for the curves, a larger
offset for the labels since text needs more clearance than a stroke does.

**Egress edges**
Previously bowed a fixed 46px past the *source's own* right edge before
curving to the proxy — fine when the proxy is close, but since it usually
sits far to one side, the curve had to sweep across the whole diagram to
reach it. Layer-skipping egress edges now use the same reserved-lane
mechanism as the long-edge fix above instead of a special-cased bow.

**Node highlighting**
Reverted to click-only (`selectedNodeId`). It previously highlighted a
node's connections on hover, which dimmed the rest of the graph on every
mouse pass.

**New: matrix view**
An adjacency-grid alternative to the node-link diagram — rows/columns
ordered proxies-then-services, a filled cell means an edge exists. Row and
column hover highlighting track independently (a node's row and its column
are usually different indices for an actual edge — an earlier iteration
shared one index for both, which meant only the diagonal could ever
highlight).

**New: `/debug/topology` page**
Unauthenticated, not linked from the sidebar. Paste or load a `GraphJson`
file and it renders through the exact same components the real Topology page
uses, with no backend involved — for iterating on layout math against
arbitrary topologies without a running stack.

**Explored and dropped**
Star (hub-and-spoke) and radial (ego-network) hub-focused layouts, and a
grouped (connected-components) layout, were implemented and evaluated
alongside the above but ultimately removed — layered (now fixed) plus matrix
covered the actual need better than either.

---

Relates to #136 .