### PR TITLE
Persist events to SQLite with time-based retention (#151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ The repository should be cloned under `/root` so the provided `setup-*.sh` scrip
   CERT_RENEWAL_DNS_PROPAGATION_SECS=30     # wait after writing the TXT record
   ```
 
+- events (UI: *Events* page) are persisted to the SQLite database rather than kept in a
+  bounded in-memory buffer, so a burst of routine events can no longer evict a warning/error
+  before anyone sees it. They're pruned automatically past a retention window, tunable via
+  optional env vars (defaults shown):
+  ```
+  EVENT_RETENTION_DAYS=7                       # how long an event is kept
+  EVENT_RETENTION_SWEEP_INTERVAL_SECS=3600     # how often the deletion sweep runs (1h)
+  ```
+
 - the gRPC control channel itself (nullnet-client/nullnet-proxy ↔ nullnet-server) is TLS-only,
   authenticated by a private CA. On first boot the server generates its own CA
   (`members/nullnet-server/grpc-tls/ca-cert.pem` + `ca-key.pem`, created once and never

--- a/members/nullnet-server/src/db/events.rs
+++ b/members/nullnet-server/src/db/events.rs
@@ -1,0 +1,201 @@
+use crate::db::AsyncSqlite;
+use crate::db::models::{EventRow, NewEventRow};
+use crate::db::schema::events;
+use diesel::prelude::*;
+use diesel::sqlite::Sqlite;
+use diesel_async::RunQueryDsl;
+use nullnet_liberror::{Error, ErrorHandler, Location, location};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Typed access to the `events` table: durable storage for `crate::events::Event`,
+/// with time-based deletion so volume never grows unbounded (see `events_retention.rs`).
+pub(crate) struct EventRepository {
+    conn: Arc<Mutex<AsyncSqlite>>,
+}
+
+impl EventRepository {
+    pub(super) fn new(conn: Arc<Mutex<AsyncSqlite>>) -> Self {
+        Self { conn }
+    }
+
+    pub(crate) async fn insert(
+        &self,
+        kind: &str,
+        severity: &str,
+        timestamp: i64,
+        payload: &str,
+    ) -> Result<(), Error> {
+        let new_row = NewEventRow {
+            kind,
+            severity,
+            timestamp,
+            payload,
+        };
+        let mut conn = self.conn.lock().await;
+        diesel::insert_into(events::table)
+            .values(&new_row)
+            .execute(&mut *conn)
+            .await
+            .handle_err(location!())?;
+        Ok(())
+    }
+
+    /// Most-recent-first page of events, filtered by any of `kind`/`severity`/
+    /// `since`/`until`, cursor-paginated via `before_id` (strictly less than —
+    /// pass the previous page's oldest `id` to continue further back).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn query(
+        &self,
+        kind: Option<&str>,
+        severity: Option<&str>,
+        since: Option<i64>,
+        until: Option<i64>,
+        before_id: Option<i64>,
+        limit: i64,
+    ) -> Result<Vec<EventRow>, Error> {
+        let mut query = events::table.into_boxed::<Sqlite>();
+        if let Some(kind) = kind {
+            query = query.filter(events::kind.eq(kind.to_owned()));
+        }
+        if let Some(severity) = severity {
+            query = query.filter(events::severity.eq(severity.to_owned()));
+        }
+        if let Some(since) = since {
+            query = query.filter(events::timestamp.ge(since));
+        }
+        if let Some(until) = until {
+            query = query.filter(events::timestamp.le(until));
+        }
+        if let Some(before_id) = before_id {
+            query = query.filter(events::id.lt(before_id));
+        }
+
+        let mut conn = self.conn.lock().await;
+        query
+            .order(events::id.desc())
+            .limit(limit)
+            .load::<EventRow>(&mut *conn)
+            .await
+            .handle_err(location!())
+    }
+
+    /// Delete every event older than `cutoff_timestamp`; returns the number of rows removed.
+    pub(crate) async fn delete_older_than(&self, cutoff_timestamp: i64) -> Result<usize, Error> {
+        let mut conn = self.conn.lock().await;
+        diesel::delete(events::table.filter(events::timestamp.lt(cutoff_timestamp)))
+            .execute(&mut *conn)
+            .await
+            .handle_err(location!())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::Db;
+
+    async fn test_db() -> Db {
+        static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "nullnet-server-events-test-{}-{n}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        Db::open(dir.join("test.db").to_str().unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn insert_and_query_round_trip() {
+        let db = test_db().await;
+        let repo = db.events();
+
+        repo.insert(
+            "node_connected",
+            "info",
+            100,
+            r#"{"type":"node_connected"}"#,
+        )
+        .await
+        .unwrap();
+        repo.insert(
+            "node_disconnected",
+            "warning",
+            200,
+            r#"{"type":"node_disconnected"}"#,
+        )
+        .await
+        .unwrap();
+        repo.insert("setup_timeout", "error", 300, r#"{"type":"setup_timeout"}"#)
+            .await
+            .unwrap();
+
+        let all = repo.query(None, None, None, None, None, 10).await.unwrap();
+        assert_eq!(all.len(), 3);
+        // most-recent-first
+        assert_eq!(all[0].kind, "setup_timeout");
+        assert_eq!(all[2].kind, "node_connected");
+
+        let errors_only = repo
+            .query(None, Some("error"), None, None, None, 10)
+            .await
+            .unwrap();
+        assert_eq!(errors_only.len(), 1);
+        assert_eq!(errors_only[0].kind, "setup_timeout");
+
+        let since_150 = repo
+            .query(None, None, Some(150), None, None, 10)
+            .await
+            .unwrap();
+        assert_eq!(since_150.len(), 2);
+
+        let until_150 = repo
+            .query(None, None, None, Some(150), None, 10)
+            .await
+            .unwrap();
+        assert_eq!(until_150.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pagination_cursor_walks_backwards_through_pages() {
+        let db = test_db().await;
+        let repo = db.events();
+        for i in 0..5 {
+            repo.insert("proxy_request_routed", "info", 100 + i, "{}")
+                .await
+                .unwrap();
+        }
+
+        let page1 = repo.query(None, None, None, None, None, 2).await.unwrap();
+        assert_eq!(page1.len(), 2);
+        let oldest_id_in_page1 = page1.last().unwrap().id;
+
+        let page2 = repo
+            .query(None, None, None, None, Some(oldest_id_in_page1), 2)
+            .await
+            .unwrap();
+        assert_eq!(page2.len(), 2);
+        assert!(page2.iter().all(|r| r.id < oldest_id_in_page1));
+    }
+
+    #[tokio::test]
+    async fn delete_older_than_prunes_only_stale_rows() {
+        let db = test_db().await;
+        let repo = db.events();
+        repo.insert("node_connected", "info", 100, "{}")
+            .await
+            .unwrap();
+        repo.insert("node_connected", "info", 500, "{}")
+            .await
+            .unwrap();
+
+        let deleted = repo.delete_older_than(200).await.unwrap();
+        assert_eq!(deleted, 1);
+
+        let remaining = repo.query(None, None, None, None, None, 10).await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].timestamp, 500);
+    }
+}

--- a/members/nullnet-server/src/db/migrations/2026-08-13-000001_create_events/down.sql
+++ b/members/nullnet-server/src/db/migrations/2026-08-13-000001_create_events/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE events;

--- a/members/nullnet-server/src/db/migrations/2026-08-13-000001_create_events/up.sql
+++ b/members/nullnet-server/src/db/migrations/2026-08-13-000001_create_events/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE events (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind      TEXT NOT NULL,
+    severity  TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    payload   TEXT NOT NULL
+);
+
+CREATE INDEX events_timestamp_idx ON events (timestamp);
+CREATE INDEX events_kind_idx ON events (kind);
+CREATE INDEX events_severity_idx ON events (severity);

--- a/members/nullnet-server/src/db/mod.rs
+++ b/members/nullnet-server/src/db/mod.rs
@@ -6,10 +6,12 @@
 //! always have; nothing calls into those two repositories yet, so that part
 //! of this module's API surface is unused until that migration happens. The
 //! auth repositories (`users`/`user_scopes`/`refresh_tokens`/`login_attempts`)
-//! back the server's JWT auth system and are fully wired up.
+//! back the server's JWT auth system and are fully wired up, as is `events`
+//! (durable storage for `crate::events::Event`, pruned by `events_retention.rs`).
 #![allow(dead_code)]
 
 mod certs;
+mod events;
 mod login_attempts;
 mod models;
 mod refresh_tokens;
@@ -19,6 +21,7 @@ mod user_scopes;
 mod users;
 
 pub(crate) use certs::CertRepository;
+pub(crate) use events::EventRepository;
 pub(crate) use login_attempts::LoginAttemptRepository;
 pub(crate) use refresh_tokens::RefreshTokenRepository;
 pub(crate) use services::ServiceRepository;
@@ -113,6 +116,10 @@ impl Db {
 
     pub(crate) fn login_attempts(&self) -> LoginAttemptRepository {
         LoginAttemptRepository::new(self.conn.clone())
+    }
+
+    pub(crate) fn events(&self) -> EventRepository {
+        EventRepository::new(self.conn.clone())
     }
 }
 

--- a/members/nullnet-server/src/db/models.rs
+++ b/members/nullnet-server/src/db/models.rs
@@ -1,5 +1,6 @@
 use crate::db::schema::{
-    certificates, dns_credentials, login_attempts, refresh_tokens, services, user_scopes, users,
+    certificates, dns_credentials, events, login_attempts, refresh_tokens, services, user_scopes,
+    users,
 };
 use diesel::prelude::*;
 
@@ -162,4 +163,30 @@ pub(crate) struct NewLoginAttempt<'a> {
     pub(crate) failed_count: i32,
     pub(crate) locked_until: Option<i64>,
     pub(crate) updated_at: i64,
+}
+
+/// One persisted event row. `payload` is the event's own JSON serialization
+/// (via `crate::events::Event`'s `Serialize` impl) — `kind`/`severity`/
+/// `timestamp` are pulled out as real columns purely so they're indexable;
+/// everything else stays in `payload` rather than one column per variant field.
+#[derive(Queryable, Selectable, Identifiable, Debug, Clone)]
+#[diesel(table_name = events)]
+#[diesel(primary_key(id))]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub(crate) struct EventRow {
+    pub(crate) id: i64,
+    pub(crate) kind: String,
+    pub(crate) severity: String,
+    pub(crate) timestamp: i64,
+    pub(crate) payload: String,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[diesel(table_name = events)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub(crate) struct NewEventRow<'a> {
+    pub(crate) kind: &'a str,
+    pub(crate) severity: &'a str,
+    pub(crate) timestamp: i64,
+    pub(crate) payload: &'a str,
 }

--- a/members/nullnet-server/src/db/schema.rs
+++ b/members/nullnet-server/src/db/schema.rs
@@ -65,6 +65,16 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    events (id) {
+        id -> BigInt,
+        kind -> Text,
+        severity -> Text,
+        timestamp -> BigInt,
+        payload -> Text,
+    }
+}
+
 diesel::joinable!(dns_credentials -> certificates (domain));
 diesel::joinable!(user_scopes -> users (user_id));
 diesel::joinable!(refresh_tokens -> users (user_id));
@@ -75,4 +85,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     user_scopes,
     refresh_tokens,
     login_attempts,
+    events,
 );

--- a/members/nullnet-server/src/events.rs
+++ b/members/nullnet-server/src/events.rs
@@ -1,9 +1,9 @@
-use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::db::Db;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::broadcast;
 
 fn now_secs() -> u64 {
     SystemTime::now()
@@ -18,6 +18,16 @@ pub(crate) enum Severity {
     Info,
     Warning,
     Error,
+}
+
+impl Severity {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warning => "warning",
+            Self::Error => "error",
+        }
+    }
 }
 
 /// Wraps an event with its severity for serialization. Produces a flat JSON
@@ -1306,59 +1316,127 @@ impl Event {
     }
 }
 
-/// Shared event store: ring buffer + broadcast channel for SSE subscribers.
-#[derive(Clone, Debug)]
+/// One page of persisted events: each entry is the flat envelope JSON
+/// (`{"severity":...,"type":...,...fields}`, matching what `EventEnvelope`
+/// used to produce) built straight from the stored payload, so callers never
+/// need to deserialize back into an `Event`. `next_before_id`, when present,
+/// is the cursor for fetching the next (older) page.
+pub(crate) struct EventPage {
+    pub(crate) events: Vec<serde_json::Value>,
+    pub(crate) next_before_id: Option<i64>,
+}
+
+/// Shared event store: durably backed by the `events` DB table (pruned on a
+/// retention timer — see `events_retention.rs`), plus a broadcast channel for
+/// live SSE subscribers. `db` is filled in once via [`Self::attach_db`] —
+/// the many in-process unit tests that build an `Orchestrator` directly never
+/// call it, so their events still broadcast live but aren't persisted, which
+/// is all those tests need.
+#[derive(Clone)]
 pub(crate) struct EventStore {
-    buffer: Arc<Mutex<VecDeque<Event>>>,
-    capacity: usize,
+    db: Arc<OnceLock<Db>>,
     tx: broadcast::Sender<Event>,
+}
+
+impl std::fmt::Debug for EventStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventStore")
+            .field("db_attached", &self.db.get().is_some())
+            .finish()
+    }
 }
 
 impl EventStore {
     pub(crate) fn new() -> Self {
-        let capacity = std::env::var("EVENT_BUFFER_SIZE")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(1000_usize);
         let (tx, _) = broadcast::channel(512);
         Self {
-            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
-            capacity,
+            db: Arc::new(OnceLock::new()),
             tx,
         }
     }
 
+    /// Wire in DB-backed persistence. A no-op after the first call.
+    pub(crate) fn attach_db(&self, db: Db) {
+        let _ = self.db.set(db);
+    }
+
     pub(crate) async fn emit(&self, event: Event) {
-        let mut buf = self.buffer.lock().await;
-        if buf.len() >= self.capacity {
-            buf.pop_front();
+        if let Some(db) = self.db.get() {
+            let kind = event.kind();
+            match serde_json::to_value(&event) {
+                Ok(payload) => {
+                    let timestamp = payload
+                        .get("timestamp")
+                        .and_then(serde_json::Value::as_i64)
+                        .unwrap_or_else(|| now_secs() as i64);
+                    if let Err(e) = db
+                        .events()
+                        .insert(
+                            kind,
+                            event.severity().as_str(),
+                            timestamp,
+                            &payload.to_string(),
+                        )
+                        .await
+                    {
+                        eprintln!("Failed to persist event '{kind}': {e:?}");
+                    }
+                }
+                Err(e) => eprintln!("Failed to serialize event '{kind}' for persistence: {e:#}"),
+            }
         }
-        buf.push_back(event.clone());
-        drop(buf);
         let _ = self.tx.send(event);
     }
 
-    /// Return stored events, optionally filtered by kind and/or severity, capped at limit.
-    /// `limit` takes the most recent N events.
-    pub(crate) async fn snapshot(
+    /// Most-recent-first page of persisted events, optionally filtered by
+    /// kind/severity/time range and cursor-paginated via `before_id`. Returns
+    /// an empty page (no error) if no DB has been attached yet.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn query(
         &self,
-        limit: Option<usize>,
         kind: Option<&str>,
         severity: Option<Severity>,
-    ) -> Vec<Event> {
-        let buf = self.buffer.lock().await;
-        let filtered: Vec<Event> = buf
-            .iter()
-            .filter(|e| kind.is_none_or(|k| e.kind() == k))
-            .filter(|e| severity.is_none_or(|s| e.severity() == s))
-            .cloned()
+        since: Option<i64>,
+        until: Option<i64>,
+        before_id: Option<i64>,
+        limit: i64,
+    ) -> EventPage {
+        let Some(db) = self.db.get() else {
+            return EventPage {
+                events: vec![],
+                next_before_id: None,
+            };
+        };
+        let severity_str = severity.map(Severity::as_str);
+        let rows = db
+            .events()
+            .query(kind, severity_str, since, until, before_id, limit)
+            .await
+            .unwrap_or_default();
+        // Another row exists past this page only if it came back full.
+        let next_before_id = (rows.len() as i64 >= limit)
+            .then(|| rows.last().map(|r| r.id))
+            .flatten();
+        let events = rows
+            .into_iter()
+            .map(|row| {
+                let mut obj = serde_json::from_str::<serde_json::Value>(&row.payload)
+                    .ok()
+                    .and_then(|v| match v {
+                        serde_json::Value::Object(map) => Some(map),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+                obj.insert(
+                    "severity".to_string(),
+                    serde_json::Value::String(row.severity),
+                );
+                serde_json::Value::Object(obj)
+            })
             .collect();
-        match limit {
-            Some(n) => {
-                let start = filtered.len().saturating_sub(n);
-                filtered[start..].to_vec()
-            }
-            None => filtered,
+        EventPage {
+            events,
+            next_before_id,
         }
     }
 

--- a/members/nullnet-server/src/events_retention.rs
+++ b/members/nullnet-server/src/events_retention.rs
@@ -1,0 +1,59 @@
+//! Background sweep that deletes persisted events past the retention window.
+//! Event volume is unbounded over time (issue #151); this keeps the `events`
+//! table's size bounded by age instead. Structurally mirrors `cert_renewal.rs`.
+use crate::db::Db;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::time::{self, MissedTickBehavior};
+
+const SECS_PER_DAY: u64 = 86_400;
+
+pub(crate) struct RetentionConfig {
+    /// How long an event is kept before it's eligible for deletion.
+    retention_secs: u64,
+    /// How often to run the deletion sweep.
+    sweep_interval_secs: u64,
+}
+
+impl RetentionConfig {
+    pub(crate) fn from_env() -> Self {
+        Self {
+            retention_secs: env_parsed::<u64>("EVENT_RETENTION_DAYS", 7) * SECS_PER_DAY,
+            sweep_interval_secs: env_parsed("EVENT_RETENTION_SWEEP_INTERVAL_SECS", 3_600), // 1h
+        }
+    }
+}
+
+fn env_parsed<T: std::str::FromStr>(key: &str, default: T) -> T {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// Spawn the retention loop. The first pass runs immediately, then every
+/// `sweep_interval_secs`.
+pub(crate) fn start(db: Db, config: RetentionConfig) {
+    tokio::spawn(async move {
+        let mut interval = time::interval(Duration::from_secs(config.sweep_interval_secs));
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            let cutoff = now_secs() - config.retention_secs as i64;
+            match db.events().delete_older_than(cutoff).await {
+                Ok(0) => {}
+                Ok(deleted) => println!(
+                    "Event retention: deleted {deleted} event(s) older than {}d",
+                    config.retention_secs / SECS_PER_DAY
+                ),
+                Err(e) => eprintln!("Event retention: sweep failed: {e:?}"),
+            }
+        }
+    });
+}

--- a/members/nullnet-server/src/http_server/events.rs
+++ b/members/nullnet-server/src/http_server/events.rs
@@ -1,16 +1,30 @@
 use super::auth::{AuthContext, require_scope};
 use crate::auth::Scope;
-use crate::events::{EventEnvelope, Severity};
+use crate::events::Severity;
 use crate::http_server::AppState;
 use axum::extract::{Extension, Query, State};
 use axum::response::{IntoResponse, Response};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+/// Default/maximum page size for `limit`, so a filterless request can't pull
+/// the whole (multi-day) retention window into one response.
+const DEFAULT_LIMIT: i64 = 100;
+const MAX_LIMIT: i64 = 500;
 
 #[derive(Deserialize)]
 pub(crate) struct EventsQuery {
-    limit: Option<usize>,
     kind: Option<String>,
     severity: Option<Severity>,
+    since: Option<i64>,
+    until: Option<i64>,
+    before_id: Option<i64>,
+    limit: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct EventsResponse {
+    events: Vec<serde_json::Value>,
+    next_before_id: Option<i64>,
 }
 
 pub(crate) async fn events_handler(
@@ -21,17 +35,21 @@ pub(crate) async fn events_handler(
     if let Err(resp) = require_scope(&ctx, Scope::EventsRead) {
         return resp;
     }
-    let events = state
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let page = state
         .events
-        .snapshot(params.limit, params.kind.as_deref(), params.severity)
+        .query(
+            params.kind.as_deref(),
+            params.severity,
+            params.since,
+            params.until,
+            params.before_id,
+            limit,
+        )
         .await;
-    let envelopes: Vec<EventEnvelope<'_>> = events
-        .iter()
-        .map(|e| EventEnvelope {
-            severity: e.severity(),
-            event: e,
-        })
-        .collect();
-    axum::Json(serde_json::to_value(envelopes).unwrap_or(serde_json::Value::Array(vec![])))
-        .into_response()
+    axum::Json(EventsResponse {
+        events: page.events,
+        next_before_id: page.next_before_id,
+    })
+    .into_response()
 }

--- a/members/nullnet-server/src/http_server/events_stream.rs
+++ b/members/nullnet-server/src/http_server/events_stream.rs
@@ -5,10 +5,15 @@ use crate::http_server::AppState;
 use axum::extract::{Extension, State};
 use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
-use futures::stream::{self, StreamExt};
+use futures::stream::StreamExt;
 use std::convert::Infallible;
 use tokio_stream::wrappers::BroadcastStream;
 
+/// Live tail only — no backfill. History now lives in the `events` table and
+/// is browsed via the paginated `GET /api/events` instead; replaying it here
+/// too would mean every SSE connect (there are commonly two at once: the
+/// Events page and `TopologyContext`) resends however much of the retention
+/// window has accumulated.
 pub(crate) async fn events_stream_handler(
     Extension(ctx): Extension<AuthContext>,
     State(state): State<AppState>,
@@ -16,18 +21,7 @@ pub(crate) async fn events_stream_handler(
     if let Err(resp) = require_scope(&ctx, Scope::EventsRead) {
         return resp;
     }
-    let backfill = state.events.snapshot(None, None, None).await;
     let rx = state.events.subscribe();
-
-    let backfill_stream = stream::iter(backfill.into_iter().map(|e| {
-        let env = EventEnvelope {
-            severity: e.severity(),
-            event: &e,
-        };
-        Ok::<_, Infallible>(
-            SseEvent::default().data(serde_json::to_string(&env).unwrap_or_default()),
-        )
-    }));
 
     let live_stream = BroadcastStream::new(rx).filter_map(|result| async move {
         result.ok().map(|e| {
@@ -41,7 +35,7 @@ pub(crate) async fn events_stream_handler(
         })
     });
 
-    Sse::new(backfill_stream.chain(live_stream))
+    Sse::new(live_stream)
         .keep_alive(KeepAlive::default())
         .into_response()
 }

--- a/members/nullnet-server/src/main.rs
+++ b/members/nullnet-server/src/main.rs
@@ -6,6 +6,7 @@ mod crypto;
 mod db;
 mod env;
 mod events;
+mod events_retention;
 mod geo;
 mod graphviz;
 mod grpc_tls;
@@ -98,7 +99,7 @@ async fn main() -> Result<(), Error> {
         .tls_config(tls_config)
         .handle_err(location!())?;
 
-    let nullnet = init_nullnet().await?;
+    let nullnet = init_nullnet(db.clone()).await?;
     let app_state = http_server::AppState {
         services: nullnet.services().clone(),
         routes: nullnet.routes().clone(),
@@ -111,6 +112,11 @@ async fn main() -> Result<(), Error> {
     cert_renewal::start(
         app_state.events.clone(),
         cert_renewal::RenewalConfig::from_env(),
+    );
+    // prune persisted events past the retention window (issue #151)
+    events_retention::start(
+        app_state.db.clone(),
+        events_retention::RetentionConfig::from_env(),
     );
 
     tokio::select! {
@@ -128,7 +134,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn init_nullnet() -> Result<NullnetGrpcImpl, Error> {
+async fn init_nullnet(db: db::Db) -> Result<NullnetGrpcImpl, Error> {
     if cfg!(not(debug_assertions)) {
         // custom panic hook to correctly clean up the server, even in case a secondary thread fails
         let orig_hook = panic::take_hook();
@@ -145,7 +151,7 @@ async fn init_nullnet() -> Result<NullnetGrpcImpl, Error> {
     })
     .handle_err(location!())?;
 
-    NullnetGrpcImpl::new().await
+    NullnetGrpcImpl::new(db).await
 }
 
 // fn redirect_stdout_stderr_to_file()

--- a/members/nullnet-server/src/nullnet_grpc_impl.rs
+++ b/members/nullnet-server/src/nullnet_grpc_impl.rs
@@ -228,7 +228,7 @@ fn find_service_stack<'a>(services: &'a StackMap, service_name: &str) -> Option<
 }
 
 impl NullnetGrpcImpl {
-    pub async fn new() -> Result<Self, Error> {
+    pub async fn new(db: crate::db::Db) -> Result<Self, Error> {
         let (stacks, index, route_map, startup_conflicts) = ServicesToml::load_validated().await?;
         let services = Arc::new(RwLock::new(stacks));
         let match_index = Arc::new(RwLock::new(index));
@@ -241,6 +241,10 @@ impl NullnetGrpcImpl {
         });
 
         let orchestrator = Orchestrator::new();
+        // Wired in before anything below emits, so even the startup-conflict
+        // events just below are persisted, not just broadcast to (currently
+        // nonexistent) live subscribers.
+        orchestrator.events.attach_db(db);
 
         // Conflicts detected before the event store existed: the offending
         // stacks were dropped, so report them now that we can.

--- a/members/nullnet-server/ui/src/index.css
+++ b/members/nullnet-server/ui/src/index.css
@@ -2,6 +2,12 @@
 
 /* ── Custom Properties ── */
 :root {
+  /* This app is dark-only (no light variant). Without this, the browser
+     renders native widget chrome — like a <select>'s popup list — with its
+     default light background, so our light (--t0/--t1/--t2) option text
+     ends up white-on-white. This tells it to use its dark form-control
+     palette instead, everywhere in the app, not just on one <select>. */
+  color-scheme: dark;
   --bg: #030508;
   --g1: rgba(255,255,255,.04);
   --g2: rgba(255,255,255,.07);

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -439,22 +439,6 @@ export default function Events() {
               >
                 {paused ? 'Resume' : 'Pause'}
               </button>
-              {filtered.length > 0 && (
-                <button
-                  onClick={() => setEvents([])}
-                  style={{
-                    background: 'var(--s1)',
-                    border: '1px solid var(--border)',
-                    color: 'var(--t2)',
-                    borderRadius: 4,
-                    padding: '2px 10px',
-                    fontSize: 11,
-                    cursor: 'pointer',
-                  }}
-                >
-                  Clear
-                </button>
-              )}
             </div>
           </div>
 

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -356,8 +356,8 @@ export default function Events() {
     .reverse();
 
   const chipStyle = (active: boolean, color: string) => ({
-    background: active ? color : 'var(--s1)',
-    border: `1px solid ${active ? color : 'var(--border)'}`,
+    background: active ? color : 'var(--g1)',
+    border: `1px solid ${active ? color : 'var(--gb)'}`,
     color: active ? 'var(--bg, #0a0a0a)' : 'var(--t2)',
     borderRadius: 4,
     padding: '2px 10px',
@@ -403,15 +403,18 @@ export default function Events() {
               ))}
 
               {/* Divider */}
-              <span style={{ width: 1, height: 16, background: 'var(--border)', margin: '0 2px' }} />
+              <span style={{ width: 1, height: 16, background: 'var(--gb)', margin: '0 2px' }} />
 
-              {/* Kind dropdown */}
+              {/* Kind dropdown. The popup list is a native surface, not composited
+                  over the page — it needs an explicit opaque background (the
+                  translucent --g1 wash the closed box uses would render as the
+                  browser's own default, i.e. white). */}
               <select
                 value={kindFilter}
                 onChange={e => setKindFilter(e.target.value)}
                 style={{
-                  background: 'var(--s1)',
-                  border: '1px solid var(--border)',
+                  background: 'var(--g1)',
+                  border: '1px solid var(--gb)',
                   color: 'var(--t1)',
                   borderRadius: 4,
                   padding: '2px 6px',
@@ -419,17 +422,17 @@ export default function Events() {
                   cursor: 'pointer',
                 }}
               >
-                <option value="">All types</option>
+                <option value="" style={{ background: 'var(--bg)', color: 'var(--t0)' }}>All types</option>
                 {ALL_KINDS.map(k => (
-                  <option key={k} value={k}>{KIND_LABELS[k]}</option>
+                  <option key={k} value={k} style={{ background: 'var(--bg)', color: 'var(--t0)' }}>{KIND_LABELS[k]}</option>
                 ))}
               </select>
 
               <button
                 onClick={() => setPaused(p => !p)}
                 style={{
-                  background: paused ? 'var(--blue)' : 'var(--s1)',
-                  border: '1px solid var(--border)',
+                  background: paused ? 'var(--blue)' : 'var(--g1)',
+                  border: '1px solid var(--gb)',
                   color: 'var(--t1)',
                   borderRadius: 4,
                   padding: '2px 10px',
@@ -490,8 +493,8 @@ export default function Events() {
                         onClick={loadOlder}
                         disabled={loadingOlder}
                         style={{
-                          background: 'var(--s1)',
-                          border: '1px solid var(--border)',
+                          background: 'var(--g1)',
+                          border: '1px solid var(--gb)',
                           color: 'var(--t2)',
                           borderRadius: 4,
                           padding: '4px 14px',

--- a/members/nullnet-server/ui/src/pages/Events.tsx
+++ b/members/nullnet-server/ui/src/pages/Events.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import Layout from '../components/Layout';
-import type { EventJson, Severity } from '../types';
+import { apiFetch } from '../lib/apiFetch';
+import type { EventJson, EventsPage, Severity } from '../types';
 
 const SEVERITY_COLOR: Record<Severity, string> = {
   info: 'var(--green)',
@@ -235,7 +236,24 @@ function formatTs(unix: number): string {
 }
 
 const MAX_EVENTS = 500;
+const PAGE_SIZE = 100;
 const SEVERITIES: Severity[] = ['info', 'warning', 'error'];
+
+/// Fetch one most-recent-first page of persisted events matching the given filters.
+async function fetchEventsPage(
+  kind: string,
+  severity: Severity | '',
+  beforeId: number | null,
+): Promise<EventsPage> {
+  const params = new URLSearchParams();
+  if (kind) params.set('kind', kind);
+  if (severity) params.set('severity', severity);
+  if (beforeId != null) params.set('before_id', String(beforeId));
+  params.set('limit', String(PAGE_SIZE));
+  const res = await apiFetch(`/api/events?${params.toString()}`);
+  if (!res.ok) throw new Error(`GET /api/events failed: ${res.status}`);
+  return res.json();
+}
 
 export default function Events() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -258,12 +276,58 @@ export default function Events() {
     }, { replace: true });
   }
 
+  // Oldest-first, matching the order live events arrive in. History (server-
+  // paginated, filtered by kind/severity) is prepended to the front; live SSE
+  // events are appended to the back.
   const [events, setEvents] = useState<EventJson[]>([]);
+  const [nextBeforeId, setNextBeforeId] = useState<number | null>(null);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [paused, setPaused] = useState(false);
   const [liveCount, setLiveCount] = useState(0);
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
 
+  // Reload the first page whenever the kind/severity filter changes (and on mount).
+  useEffect(() => {
+    let cancelled = false;
+    setInitialLoading(true);
+    fetchEventsPage(kindFilter, severityFilter, null)
+      .then(page => {
+        if (cancelled) return;
+        setEvents(page.events.slice().reverse());
+        setNextBeforeId(page.next_before_id);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setEvents([]);
+          setNextBeforeId(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setInitialLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [kindFilter, severityFilter]);
+
+  const loadOlder = useCallback(async () => {
+    if (nextBeforeId == null || loadingOlder) return;
+    setLoadingOlder(true);
+    try {
+      const page = await fetchEventsPage(kindFilter, severityFilter, nextBeforeId);
+      setEvents(prev => [...page.events.slice().reverse(), ...prev]);
+      setNextBeforeId(page.next_before_id);
+    } catch {
+      // leave the cursor as-is; the button just stays clickable to retry
+    } finally {
+      setLoadingOlder(false);
+    }
+  }, [kindFilter, severityFilter, nextBeforeId, loadingOlder]);
+
+  // Live tail: the stream carries no backfill (history comes from the
+  // paginated fetch above), so every message here is genuinely new.
   useEffect(() => {
     const es = new EventSource('/api/events/stream');
 
@@ -316,7 +380,7 @@ export default function Events() {
         <div className="hero-row">
           <span className="hero-num">{filtered.length}</span>
           <span className="hero-label">
-            {kindFilter ? `${kindFilter} events` : severityFilter ? `${severityFilter} events` : 'events in buffer'}
+            {kindFilter ? `${kindFilter} events` : severityFilter ? `${severityFilter} events` : 'events loaded'}
           </span>
         </div>
 
@@ -404,7 +468,7 @@ export default function Events() {
                 </tr>
               </thead>
               <tbody>
-                {filtered.length === 0 && (
+                {filtered.length === 0 && !initialLoading && (
                   <tr>
                     <td colSpan={3} style={{ color: 'var(--t2)', padding: '20px 16px' }}>
                       {kindFilter || severityFilter
@@ -435,6 +499,27 @@ export default function Events() {
                     </td>
                   </tr>
                 ))}
+                {nextBeforeId != null && (
+                  <tr>
+                    <td colSpan={3} style={{ padding: '10px 16px', textAlign: 'center' }}>
+                      <button
+                        onClick={loadOlder}
+                        disabled={loadingOlder}
+                        style={{
+                          background: 'var(--s1)',
+                          border: '1px solid var(--border)',
+                          color: 'var(--t2)',
+                          borderRadius: 4,
+                          padding: '4px 14px',
+                          fontSize: 11,
+                          cursor: loadingOlder ? 'default' : 'pointer',
+                        }}
+                      >
+                        {loadingOlder ? 'Loading…' : 'Load older'}
+                      </button>
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>

--- a/members/nullnet-server/ui/src/types.ts
+++ b/members/nullnet-server/ui/src/types.ts
@@ -154,6 +154,14 @@ export type EventJson =
   | WithSeverity & { type: 'certificate_renewal_failed'; domain: string; error_message: string }
   | WithSeverity & { type: 'certificate_credentials_store_failed'; domain: string; error_message: string };
 
+/// Response shape of `GET /api/events` — a most-recent-first page of
+/// persisted events. `next_before_id`, when present, is the cursor to pass
+/// back as `before_id` to fetch the next (older) page.
+export interface EventsPage {
+  events: EventJson[];
+  next_before_id: number | null;
+}
+
 export interface GraphNodeJson {
   id: string;
   registered: boolean;


### PR DESCRIPTION
Events were kept only in an in-memory ring buffer capped at EVENT_BUFFER_SIZE (default 1000, drop-oldest), so a burst of routine events (sticky_session_reused, proxy_request_routed, ...) could evict a warning/error before anyone saw it, and everything was lost on restart.

Events now persist to a new `events` table (kind/severity/timestamp indexed, payload JSON). A background sweep (mirrors cert_renewal.rs's interval loop) deletes rows past a retention window, configurable via EVENT_RETENTION_DAYS (default 7) and EVENT_RETENTION_SWEEP_INTERVAL_SECS (default 1h) — bounded by age instead of count, so nothing gets evicted just because other events happened to fire first.

GET /api/events is now cursor-paginated (before_id) with kind/severity/ since/until filters, backed by the DB instead of an in-memory snapshot. The Events UI fetches history through it (with a "Load older" control) instead of relying purely on whatever the SSE backfill happened to replay; the SSE stream itself now carries live events only, since history has a proper home.

EventStore's DB backing is optional (OnceLock, wired via attach_db()): the ~30 in-process unit tests that build an Orchestrator directly never attach one, so their events still broadcast live but aren't persisted, which is all a broadcast-only unit test needs.

Verification: cargo fmt/clippy -D warnings/test all clean (166 passed, 0 failed, including 3 new db::events tests); full build succeeds (includes the UI's tsc -b && vite build via build.rs). Multi-host e2e (Gate 3) not yet run — needs a real Swarm topology, still pending.

Fixes #151 