### PR TITLE
ci: install bpf-linker from a prebuilt binary instead of source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,13 @@ jobs:
         with:
           components: rust-src, rustfmt, clippy
 
-      - name: install bpf-linker
-        run: cargo install bpf-linker --locked
+      # Installs a prebuilt binary rather than compiling from source: bpf-linker's
+      # own build needs a matching local LLVM (`llvm-config` on PATH), which the
+      # runner image doesn't reliably provide and isn't worth pinning here. This
+      # is the install method aya-rs's own template CI uses.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: bpf-linker
 
       - name: Install protoc
         run: |


### PR DESCRIPTION
cargo install bpf-linker --locked compiles from source, which needs a matching local LLVM (llvm-config on PATH) - bpf-linker's own install warning calls this out as fragile. It broke on the runner with "could not find llvm-config in directories specified by ... PATH", unrelated to any change in this repo (last commit to main predates the failure, and main's last CI run had this same job passing).

Switched to taiki-e/install-action, which fetches aya-rs/bpf-linker's prebuilt release binary (verified against its manifest: bpf-linker is listed there, currently at 0.11.0, matching the version that failed to build from source) - no local LLVM needed. This is the same install method aya-rs's own aya-template CI uses.